### PR TITLE
Try to restore consensus group from relcast on startup

### DIFF
--- a/src/miner_hbbft_handler.erl
+++ b/src/miner_hbbft_handler.erl
@@ -106,7 +106,7 @@ handle_message(Index, Msg, State=#state{hbbft=HBBFT}) ->
             NewState = State#state{signatures=[{Address, Signature}|State#state.signatures]},
             case enough_signatures(NewState) of
                 {ok, Signatures} ->
-                    miner:sign_block(Signatures);
+                    ok = miner:signed_block(Signatures, State#state.artifact);
                 false ->
                     ok
             end,


### PR DESCRIPTION
Because relcast serializes the state and the messages for the group, on
startup if we should be in the consensus group, we try to restart the
consensus group with the same parameters.

This patch simply re-activates the old logic for doing so, but it takes
more care with not losing crucial state between the cracks. Crucially
we store less state in the 'miner' process and leave more state in the
backed-up relcast state. This means that each message from relcast to
the miner contains the essential information needed to perform the
action.

In addition, we explicitly store less data in the miner's state because
we don't actually need it, and it's unwise to rely on it being present
because a restart will wipe it out.

Finally, in the cases where the relcast group calls into the miner,
firstly make them *calls* so they're synchronous, and secondly make sure
they're atomic, so if they fail, and the call fails, the relcast server
crashes as well. This means that if the miner fails, so does the relcast
group and we avoid conditions where the relcast group handed off data to
the miner but the miner crashed before it could do anything about it,
leading to loss of state.