### PR TITLE
Explicitly advance the round to an absolute number

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -47,7 +47,7 @@
   0},
  {<<"hbbft">>,
   {git,"https://github.com/helium/erlang-hbbft.git",
-       {ref,"cac7a7161bfb33fa4b502d444bffaf313056ff06"}},
+       {ref,"2ef6ce07b337af4daa614157c5c57bc1405c18f2"}},
   0},
  {<<"inert">>,
   {git,"https://github.com/msantos/inert",

--- a/src/miner_hbbft_handler.erl
+++ b/src/miner_hbbft_handler.erl
@@ -52,7 +52,7 @@ handle_input({status, Ref, Worker}, State) ->
 handle_input({next_round, NextRound, TxnsToRemove}, State=#state{hbbft=HBBFT}) ->
     PrevRound = hbbft:round(HBBFT),
     case NextRound - PrevRound of
-        1 ->
+        N when N > 0 ->
             lager:info("Advancing from PreviousRound: ~p to NextRound ~p and emptying hbbft buffer", [PrevRound, NextRound]),
             %% filter any stale messages
             libp2p_group_relcast_server:filter(self(), fun(_Index, Key) ->
@@ -76,7 +76,7 @@ handle_input({next_round, NextRound, TxnsToRemove}, State=#state{hbbft=HBBFT}) -
                                                                        true
                                                                end
                                                        end),
-            case hbbft:next_round(HBBFT, TxnsToRemove) of
+            case hbbft:next_round(HBBFT, NextRound, TxnsToRemove) of
                 {NextHBBFT, ok} ->
                     maybe_deliver_deferred(State#state{hbbft=NextHBBFT}, ok);
                 {NextHBBFT, {send, NextMsgs}} ->


### PR DESCRIPTION
This avoids issues where we advance the round *relatively* but miss some
advancements, or double them up.