### PR TITLE
Update h3 dep & reduce the cases in which we try to assert a location

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -40,7 +40,7 @@
  {<<"gpb">>,{pkg,<<"gpb">>,<<"4.2.1">>},2},
  {<<"h3">>,
   {git,"https://github.com/helium/erlang-h3.git",
-       {ref,"a8d1e104035228f141cdf5d3f9743f2e55bf6d28"}},
+       {ref,"584d6b20f5b64c8c0a3570d23bebcea2537d68bc"}},
   0},
  {<<"hbbft">>,
   {git,"https://github.com/helium/erlang-hbbft.git",

--- a/src/miner.erl
+++ b/src/miner.erl
@@ -544,6 +544,9 @@ do_initial_dkg(GenesisTransactions, Addrs, State=#state{curve=Curve}) ->
     end.
 
 -spec maybe_assert_location(h3:index(), h3:resolution(), blockchain:blockchain()) -> ok.
+maybe_assert_location(_, Resolution, _) when Resolution < 10 ->
+    %% wait for a better resolution
+    ok;
 maybe_assert_location(Location, _Resolution, Chain) ->
     Address = blockchain_swarm:address(),
     Ledger = blockchain:ledger(Chain),
@@ -566,13 +569,13 @@ maybe_assert_location(Location, _Resolution, Chain) ->
                                     %% new index is a parent of the old one
                                     ok;
                                 false ->
-                                    %% check whether New Index is a child of the old one, more precise
-                                    %case Resolution > h3:get_resolution(Old) andalso lists:member(New, h3:children(Old, Resolution)) of
-                                        %true ->
-                                            blockchain_worker:assert_location_request(OwnerAddress, Location)
-                                        %false ->
-                                            %ok
-                                    %end
+                                    %% check if the parent at resolution 10 actually differs
+                                    case h3:parent(New, 10) /= h3:parent(Old, 10) of
+                                        true ->
+                                            blockchain_worker:assert_location_request(OwnerAddress, Location);
+                                        false ->
+                                            ok
+                                    end
                             catch
                                 TypeOfError:Exception ->
                                     lager:error("No Parent from H3, TypeOfError: ~p, Exception: ~p", [TypeOfError, Exception]),


### PR DESCRIPTION
Prior to this we'd very noisily assert a location enever it was
different. Instead settle on resolution 10 as the location granularity
and only assert if we've never asserted or our new assertion is outside
our current resolution 10 hexagon.