### PR TITLE
Adds a miner ebus server to allow other applications to talk to it

### DIFF
--- a/config/com.helium.Miner.conf
+++ b/config/com.helium.Miner.conf
@@ -1,0 +1,12 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="com.helium.Miner"/>
+    <allow send_interface="com.helium.Miner"/>
+  </policy>
+  <policy context="default">
+     <allow send_destination="com.helium.Miner"/>
+  </policy>
+</busconfig>

--- a/src/miner_ebus.erl
+++ b/src/miner_ebus.erl
@@ -1,0 +1,40 @@
+-module(miner_ebus).
+
+-behavior(ebus_object).
+
+-include_lib("ebus/include/ebus.hrl").
+
+-export([start_link/0, start_link/2, init/1, handle_message/3]).
+
+-record(state, {
+               }).
+
+-define(SERVER, miner_ebus).
+
+-define(MINER_APPLICATION_NAME, "com.helium.Miner").
+-define(MINER_OBJECT_PATH, "/").
+-define(MINER_INTERFACE, "com.helium.Miner").
+-define(MINER_OBJECT(M), ?MINER_INTERFACE ++ "." ++ M).
+
+-define(MINER_MEMBER_PUBKEY, "PubKey").
+
+start_link() ->
+    {ok, Bus} = ebus:system(),
+    start_link(Bus, []).
+
+start_link(Bus, Args) ->
+    ok = ebus:request_name(Bus, ?MINER_APPLICATION_NAME),
+    ebus_object:start_link(Bus, ?MINER_OBJECT_PATH, ?MODULE, Args, []).
+
+init(_Args) ->
+    erlang:register(?SERVER, self()),
+    {ok, #state{}}.
+
+
+handle_message(?MINER_OBJECT(?MINER_MEMBER_PUBKEY), _Msg, State=#state{}) ->
+    PubKeyBin = miner:pubkey_bin(),
+    {reply, [string], [libp2p_crypto:bin_to_b58(PubKeyBin)], State};
+
+handle_message(Member, _Msg, State) ->
+    lager:warning("Unhandled dbus message ~p", [Member]),
+    {reply_error, ?DBUS_ERROR_NOT_SUPPORTED, Member, State}.


### PR DESCRIPTION
This removes the config proxy from miner since it was no longer used and introduces a miner_ebus server which allows external apps like gateway_config to talk to miner. The first example of this is the PubKey attribute which gets the public key from the miner