### PR TITLE
Support add gateway requests

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -73,7 +73,7 @@ pubkey_bin() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
--spec add_gateway_txn(OwnerB58::string()) -> {ok, binary()} | {error, invalid_owner}.
+-spec add_gateway_txn(OwnerB58::string()) -> {ok, binary()} | {error, term()}.
 add_gateway_txn(OwnerB58) ->
     gen_server:call(?MODULE, {add_gateway_txn, OwnerB58}).
 


### PR DESCRIPTION
This enables the miner to receive an add gatewayrequest for a given
owner public key. It returns a signed add_gateway_v1 transaction for
the given owner and the key of "this" gateway