### PR TITLE
Prune outbound messages whenever we go to a new round

### DIFF
--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -73,7 +73,7 @@ handle_command({skip, Ref, Worker}, State) ->
             {reply, ok, [new_epoch | fixup_msgs(NextMsgs)], State#state{hbbft=NextHBBFT, signatures=[], artifact=undefined}}
     end;
 %% XXX this is a hack because we don't yet have a way to message this process other ways
-handle_command({next_round, NextRound, TxnsToRemove, Sync}, State=#state{hbbft=HBBFT, ledger=Ledger0}) ->
+handle_command({next_round, NextRound, TxnsToRemove, _Sync}, State=#state{hbbft=HBBFT, ledger=Ledger0}) ->
     PrevRound = hbbft:round(HBBFT),
     case NextRound - PrevRound of
         N when N > 0 ->
@@ -82,9 +82,9 @@ handle_command({next_round, NextRound, TxnsToRemove, Sync}, State=#state{hbbft=H
             lager:info("Advancing from PreviousRound: ~p to NextRound ~p and emptying hbbft buffer", [PrevRound, NextRound]),
             case hbbft:next_round(filter_txn_buf(HBBFT, Ledger), NextRound, TxnsToRemove) of
                 {NextHBBFT, ok} ->
-                    {reply, ok, [new_epoch || Sync], State#state{ledger=Ledger, hbbft=NextHBBFT, signatures=[], artifact=undefined}};
+                    {reply, ok, [ new_epoch ], State#state{ledger=Ledger, hbbft=NextHBBFT, signatures=[], artifact=undefined}};
                 {NextHBBFT, {send, NextMsgs}} ->
-                    {reply, ok, [new_epoch || Sync] ++ fixup_msgs(NextMsgs), State#state{ledger=Ledger, hbbft=NextHBBFT, signatures=[], artifact=undefined}}
+                    {reply, ok, [ new_epoch ] ++ fixup_msgs(NextMsgs), State#state{ledger=Ledger, hbbft=NextHBBFT, signatures=[], artifact=undefined}}
             end;
         0 ->
             lager:warning("Already at the current Round: ~p", [NextRound]),

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -148,7 +148,7 @@ basic(_Config) ->
     {AddBlockMsgs, Msgs1} = lists:split(4, Msgs),
     lists:foreach(
         fun(Msg) ->
-            ?assertMatch({blockchain_event, {add_block, _, true}}, Msg)
+            ?assertMatch({blockchain_event, {add_block, _, _}}, Msg)
         end,
         AddBlockMsgs
     ),


### PR DESCRIPTION
Because we've now seperated inbound from outbound messages, we know, for
certain, that any pending outbound messages can be deleted whenever we
move to a new round (by definition all messages required to reach the
new round have already been sent).

Additionally fix a test.