### PR TITLE
Fix extension scripts: avoid warning on serial console, have exit status

### DIFF
--- a/scripts/extensions/authorize
+++ b/scripts/extensions/authorize
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc miner_console command authorize $@
+exit $?

--- a/scripts/extensions/dkg
+++ b/scripts/extensions/dkg
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc miner_console command dkg $@
+exit $?

--- a/scripts/extensions/genesis
+++ b/scripts/extensions/genesis
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc miner_console command genesis $@
+exit $?

--- a/scripts/extensions/hbbft
+++ b/scripts/extensions/hbbft
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc miner_console command hbbft $@
+exit $?

--- a/scripts/extensions/info
+++ b/scripts/extensions/info
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ -t 0 ] ; then
-    export CLIQUE_COLUMNS=`stty size | cut -d ' ' -f 2`
+    export CLIQUE_COLUMNS=`stty size 2>/dev/null | cut -d ' ' -f 2`
 fi
 relx_nodetool rpc miner_console command info $@
+exit $?


### PR DESCRIPTION
Extension scripts are expected to call exit themselves, or the runner
script will exit with code 1. This breaks using the miner extension
commands in shell scripts. To fix this we exit with the exit code of the
RPC call (if the RPC call does not return with `ok`, the exit status
will be non-zero).