### PR TITLE
fix the PoC test race

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -52,9 +52,9 @@
   [
    {batch_size, 500},
    {curve, 'SS512'},
-   {block_time, 15000},
+   {block_time, 0},
    {update_dir, "{{update_dir}}"},
-   {election_interval, infinity}
+   {election_interval, 20}
    %% {h3_resolution, 13},
    %% {radio_device, {"127.0.0.1", 45000, 5678}}
   ]}

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -389,7 +389,7 @@ rcv_loop(Miner, I, Acc0) ->
                         blockchain_block:transactions(Block)
                     )
             end,
-            ct:pal("I ~p Acc1 ~p", [I, Acc1]),
+            ct:pal("counter ~p accumulated lengths ~p", [I, Acc1]),
             rcv_loop(Miner, I-1, Acc1);
         {blockchain_event, {add_block, _Hash, true, _}} ->
             rcv_loop(Miner, I, Acc0)


### PR DESCRIPTION
it looks like the registration for this handler was occasionally happening too early, but somehow not crashing.  moving it later seems to cause the test to pass consistently.