### PR TITLE
Avoid receiving duplicate DKG signatures

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -8,13 +8,14 @@
   [
    {base_dir, "data"},
    {seed_nodes, ""},
-   {seed_nodes_dns, ""}
+   {seed_nodes_dns, ""},
+   {num_consensus_members, 7}
   ]},
  {miner,
   [
    {use_ebus, false},
-   {block_time, 0},
-   {election_interval, 20},
+   {block_time, 3000},
+   {election_interval, 15},
    {radio_device, undefined}
   ]}
 ].


### PR DESCRIPTION
- Switch to a map to keep track of DKG signatures
- Update DKG test to use chain var
- Update dev.config to use 7 consensus members (run.sh gets broke with 13 we configured in the last reboot)

I've tested that a local chain grows with/without elections configured which is a good sign.