### PR TITLE
make dkg test fail faster

### DIFF
--- a/test/miner_dkg_SUITE.erl
+++ b/test/miner_dkg_SUITE.erl
@@ -44,7 +44,8 @@ initial_dkg_test(Config) ->
     DKGResults = miner_ct_utils:pmap(
                    fun(Miner) ->
                            ct_rpc:call(Miner, miner_consensus_mgr, initial_dkg,
-                                       [InitialPaymentTransactions, Addresses, N, Curve])
+                                       [InitialPaymentTransactions, Addresses, N, Curve],
+                                       timer:seconds(60))
                    end, Miners),
-    true = lists:all(fun(Res) -> Res == ok end, DKGResults),
+    ?assertEqual([ok], lists:usort(DKGResults)),
     {comment, DKGResults}.


### PR DESCRIPTION
ct_rpc defaults to an infinite timeout.  if for some reason the call doesn't return, this test will never return.  as such, I add a timeout to make sure that it returns in a reasonable amount of time.  for redundancy, I also added a timeout to pmap.