### PR TITLE
add gossip phase to block signing

### DIFF
--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -346,7 +346,7 @@ map_ids(Sigs, Members0) ->
     Members = lists:zip(Members0, lists:seq(1, length(Members0))),
     lists:map(fun({Addr, _Sig}) ->
                       %% find member index
-                      {_, ID} = list:keyfind(Addr, 1, Members),
+                      {_, ID} = lists:keyfind(Addr, 1, Members),
                       ID
               end,
               Sigs).


### PR DESCRIPTION
when the group has become partitioned, we often see rounds getting stuck in the signature phase.  to combat this, we have nodes change phase once they have seen F+1 valid signatures.  in the new phase, they send out all of the signatures that they've seen so far, and then merge the signatures that they recieve with their existing set.  this should help with asymmetric network partitions at the cost of some additional network bandwidth.