### PR TITLE
initial height of 0 is not correct

### DIFF
--- a/src/miner_consensus_mgr.erl
+++ b/src/miner_consensus_mgr.erl
@@ -37,7 +37,7 @@
          current_dkg :: undefined | pid(),
          dkg_await :: undefined | {reference(), term()},
          consensus_pos :: undefined | pos_integer(),
-         initial_height = 0 :: non_neg_integer(),
+         initial_height = 1 :: non_neg_integer(),
          delay = 0 :: integer(),
          chain :: undefined | blockchain:blockchain(),
          election_running = false :: boolean()


### PR DESCRIPTION
the initial height of the chain is 1 at genesis, not 0.  This was causing some offset problems for elections, when a miner was not part of the initial group, and started at 0 because it had been force-cleaned by an upgrade into an image with a new genesis block.

There are two other paths that set that code (genesis participation and non-0 height restore) and both of them set the height correctly.