### PR TITLE
Don't lock the keyslot. Private keys are not accessible either way.

### DIFF
--- a/src/miner_sup.erl
+++ b/src/miner_sup.erl
@@ -106,11 +106,11 @@ init(_Args) ->
                                                    GetPublicKey(KS+1)
                                            end;
                                        {error, _} ->
-                                           %% key is not present, generate one and lock it
+                                           %% key is not present, generate one
+                                           %%
                                            %% XXX this is really not the best thing to do here
                                            %% but deadlines rule everything around us
                                            ok = gen_compact_key(ECCPid, KS),
-                                           ecc508:lock(ECCPid, {slot, KS}),
                                            GetPublicKey(KS)
                                    end
                            end,


### PR DESCRIPTION
This allows us to roll the same keyslot _if_ we need to