### PR TITLE
Output both actual and assume-valid block height when appropriate

### DIFF
--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -91,7 +91,7 @@ info_height(["info", "height"], [], []) ->
         true ->
             [clique_status:text(Epoch ++ "\t\t" ++ integer_to_list(Height))];
         false ->
-            [clique_status:text([Epoch, "\t\t", integer_to_list(SyncHeight), "*"])]
+            [clique_status:text([Epoch, "\t\t", integer_to_list(Height), "\t\t", integer_to_list(SyncHeight), "*"])]
     end;
 info_height([_, _, _], [], []) ->
     usage.


### PR DESCRIPTION
This helps improve visibility when absorbing assume-valid blocks and
also prevents false detection of blockchain stalls.