### PR TITLE
lower the number of retained rocks logs to something reasonable

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -55,7 +55,8 @@
      {memtable_memory_budget, 33554432},  % 32MB
      {arena_block_size, 131072}, % 128k
      {write_buffer_size, 131072},
-     {max_write_buffer_number, 4}
+     {max_write_buffer_number, 4},
+     {keep_log_file_num, 5}
     ]}
   ]},
  {miner,


### PR DESCRIPTION
helps prevent peerbook, block, and ledger bloat