### PR TITLE
save progress, change delay

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},3},
  {<<"blockchain">>,
   {git,"git@github.com:helium/blockchain-core.git",
-       {ref,"31dcf99bad468cc9122d5b7ece9c720b14cfdb90"}},
+       {ref,"e1e1fee0e26ed17c994659fb9a6d2a8963f7aa57"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",

--- a/src/miner_sup.erl
+++ b/src/miner_sup.erl
@@ -168,7 +168,9 @@ init(_Args) ->
          {batch_size, BatchSize}
         ],
 
-    POCOpts = #{},
+    POCOpts = #{
+        base_dir => BaseDir
+    },
 
     OnionServer =
         case application:get_env(miner, radio_device, undefined) of

--- a/src/poc/miner_poc_statem.erl
+++ b/src/poc/miner_poc_statem.erl
@@ -50,10 +50,15 @@
 -define(CHALLENGE_RETRY, 3).
 -define(RECEIVING_TIMEOUT, 10).
 -define(RECEIPTS_TIMEOUT, 10).
+-define(STATE_FILE, "miner_poc_statem.state").
 
 -record(data, {
+    base_dir :: file:filename_all() | undefined,
     blockchain :: blockchain:blockchain() | undefined,
     address :: libp2p_crypto:pubkey_bin(),
+    poc_interval :: non_neg_integer() | undefined,
+
+    state = requesting :: state(),
     secret :: binary() | undefined,
     onion_keys :: keys() | undefined,
     challengees = [] :: [{libp2p_crypto:pubkey_bin(), binary()}],
@@ -65,11 +70,11 @@
     mining_delay = ?MINING_DELAY :: non_neg_integer(),
     mining_hash :: undefined | binary(),
     mining_ledger :: undefined | blockchain_ledger_v1:ledger(),
-    poc_interval :: non_neg_integer() | undefined,
     retry = ?CHALLENGE_RETRY :: non_neg_integer(),
     receipts_timeout = ?RECEIPTS_TIMEOUT :: non_neg_integer()
 }).
 
+-type state() :: requesting | mining | delaying | targeting | challenging | receiving | submitting | waiting.
 -type data() :: #data{}.
 -type keys() :: #{secret => libp2p_crypto:privkey(), public => libp2p_crypto:pubkey()}.
 
@@ -94,10 +99,18 @@ init(Args) ->
     ok = miner_onion:add_stream_handler(blockchain_swarm:swarm()),
     Address = blockchain_swarm:pubkey_bin(),
     Blockchain = blockchain_worker:blockchain(),
+    BaseDir = maps:get(base_dir, Args, undefined),
     %% this should really only be overriden for testing
     Delay = maps:get(delay, Args, undefined),
     lager:info("init with ~p", [Args]),
-    {ok, requesting, #data{blockchain=Blockchain, address=Address, poc_interval=Delay}}.
+    case load_data(BaseDir) of
+        {error, _} ->
+            {ok, requesting, #data{base_dir=BaseDir, blockchain=Blockchain,
+                                   address=Address, poc_interval=Delay, state=requesting}};
+        {ok, State, Data} ->
+            {ok, State, Data#data{base_dir=BaseDir, blockchain=Blockchain,
+                                  address=Address, poc_interval=Delay, state=State}}
+    end.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -111,10 +124,6 @@ terminate(_Reason, _State) ->
 %% gen_statem callbacks
 %% ------------------------------------------------------------------
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 requesting(info, Msg, #data{blockchain=undefined}=Data) ->
     case blockchain_worker:blockchain() of
         undefined ->
@@ -136,42 +145,37 @@ requesting(info, {blockchain_event, {add_block, BlockHash, false, Ledger}}, #dat
             lager:info("request allowed @ ~p", [BlockHash]),
             ok = blockchain_worker:submit_txn(Txn),
             lager:info("submitted poc request ~p", [Txn]),
-            {next_state, mining, Data#data{secret=Secret, onion_keys=Keys, responses=#{}, poc_hash=BlockHash}}
+            {next_state, mining, save_data(Data#data{state=mining, secret=Secret,
+                                                      onion_keys=Keys, responses=#{},
+                                                      poc_hash=BlockHash})}
     end;
 requesting(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 mining(info, {blockchain_event, {add_block, BlockHash, _, PinnedLedger}}, #data{mining_timeout=MiningTimeout}=Data) ->
     case find_request(BlockHash, Data) of
         ok ->
             RandomDelay = rand:uniform(?MINING_DELAY),
             lager:info("request was mined @ ~p delaying ~p blocks", [BlockHash, RandomDelay]),
-            {next_state, delaying, Data#data{mining_timeout=?MINING_TIMEOUT,
-                                             mining_hash=BlockHash,
-                                             mining_delay=RandomDelay,
-                                             mining_ledger=PinnedLedger}};
+            {next_state, delaying, save_data(Data#data{state=delaying, 
+                                                       mining_timeout=?MINING_TIMEOUT,
+                                                       mining_hash=BlockHash,
+                                                       mining_delay=RandomDelay,
+                                                       mining_ledger=PinnedLedger})};
         {error, _Reason} ->
              case MiningTimeout > 0 of
                 true ->
                     {keep_state, Data#data{mining_timeout=MiningTimeout-1}};
                 false ->
                     lager:error("did not see PoC request in last ~p block, retrying", [?MINING_TIMEOUT]),
-                    {next_state, requesting, Data#data{mining_timeout=?MINING_TIMEOUT}}
+                    {next_state, requesting, save_data(Data#data{state=requesting, mining_timeout=?MINING_TIMEOUT})}
             end
     end;
 mining(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 delaying(info, {blockchain_event, {add_block, _, _, _}}, #data{mining_delay=Delay}=Data0) when Delay > 0 ->
-    {keep_state, Data0#data{mining_delay=Delay-1}};
+    {keep_state, save_data(Data0#data{mining_delay=Delay-1})};
 delaying(info, {blockchain_event, {add_block, _, _, _}}, #data{blockchain=Chain,
                                                                address=Challenger,
                                                                secret=Secret,
@@ -181,35 +185,28 @@ delaying(info, {blockchain_event, {add_block, _, _, _}}, #data{blockchain=Chain,
     lager:info("delay over, moving to targeting"),
     {ok, Block} = blockchain:get_block(MiningHash, Chain),
     Height = blockchain_block:height(Block),
+    %% TODO: change this to an internal event
     self() ! {target, <<Secret/binary, MiningHash/binary, Challenger/binary>>, Height, PinnedLedger},
-    {next_state, targeting, Data};
+    {next_state, targeting, save_data(Data#data{state=targeting, mining_hash=undefined})};
 delaying(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 targeting(info, {target, _, _, _}, #data{retry=0}=Data) ->
     lager:error("targeting/challenging failed ~p times back to requesting", [?CHALLENGE_RETRY]),
-    {next_state, requesting, Data#data{retry=?CHALLENGE_RETRY}};
+    {next_state, requesting, save_data(Data#data{state=requesting, retry=?CHALLENGE_RETRY})};
 targeting(info, {target, Entropy, Height, Ledger}, Data) ->
     case blockchain_poc_path:target(Entropy, Ledger, blockchain_swarm:pubkey_bin()) of
         {Target, Gateways} ->
             lager:info("target found ~p, challenging, hash: ~p", [Target, Entropy]),
             self() ! {challenge, Entropy, Target, Gateways, Height, Ledger},
-            {next_state, challenging, Data#data{challengees=[]}};
+            {next_state, challenging, save_data(Data#data{state=challenging, challengees=[]})};
         no_target ->
             lager:warning("no target found, back to requesting"),
-            {next_state, requesting, Data#data{retry=?CHALLENGE_RETRY}}
+            {next_state, requesting, save_data(Data#data{state=requesting, retry=?CHALLENGE_RETRY})}
     end;
 targeting(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 challenging(info, {challenge, Entropy, Target, Gateways, Height, Ledger}, #data{retry=Retry,
                                                                                 onion_keys=OnionKey,
                                                                                 poc_hash=BlockHash
@@ -228,7 +225,7 @@ challenging(info, {challenge, Entropy, Target, Gateways, Height, Ledger}, #data{
             lager:error("could not build path for ~p: ~p", [Target, Reason]),
             lager:info("selecting new target"),
             self() ! {target, Entropy, Height, Ledger},
-            {next_state, targeting, Data#data{retry=Retry-1}};
+            {next_state, targeting, save_data(Data#data{state=targeting, retry=Retry-1})};
         {Attempt, {ok, Path}} ->
             lager:info("path created ~p", [Path]),
             N = erlang:length(Path),
@@ -242,43 +239,39 @@ challenging(info, {challenge, Entropy, Target, Gateways, Height, Ledger}, #data{
             P2P = libp2p_crypto:pubkey_bin_to_p2p(Start),
             case send_onion(P2P, Onion, 3) of
                 ok ->
-                    {next_state, receiving, Data#data{challengees=lists:zip(Path, LayerData), packet_hashes=lists:zip(Path, LayerHashes)}};
+                    {next_state, receiving, save_data(Data#data{state=receiving, challengees=lists:zip(Path, LayerData), packet_hashes=lists:zip(Path, LayerHashes)})};
                 {error, Reason} ->
                     lager:error("failed to dial 1st hotspot (~p): ~p", [P2P, Reason]),
                     lager:info("selecting new target"),
                     self() ! {target, Entropy, Height, Ledger},
-                    {next_state, targeting, Data#data{retry=Retry-1}}
+                    {next_state, targeting, save_data(Data#data{state=targeting, retry=Retry-1})}
             end;
         {'DOWN', Ref, process, _Pid, Reason} ->
             lager:error("blockchain_poc_path went down ~p: ~p", [Reason, {Entropy, Target, Gateways, Height}]),
-            {next_state, targeting, Data#data{retry=Retry-1}}
+            {next_state, targeting, save_data(Data#data{state=targeting, retry=Retry-1})}
     after Timeout ->
         erlang:demonitor(Ref, [flush]),
         erlang:exit(Pid, kill),
         lager:error("blockchain_poc_path took too long: Entropy ~p Target ~p Height ~p", [Entropy, Target, Height]),
-        {next_state, requesting, Data#data{retry=?CHALLENGE_RETRY}}
+        {next_state, requesting, save_data(Data#data{state=requesting, retry=?CHALLENGE_RETRY})}
     end;
 challenging(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 receiving(info, {blockchain_event, {add_block, _Hash, _, _}}, #data{receiving_timeout=0, responses=Responses}=Data) ->
     case maps:size(Responses) of
         0 ->
             lager:warning("timing out, no receipts @ ~p", [_Hash]),
             %% we got nothing, no reason to submit
-            {next_state, requesting, Data#data{retry=?CHALLENGE_RETRY}};
+            {next_state, requesting, save_data(Data#data{state=requesting, retry=?CHALLENGE_RETRY})};
         _ ->
             lager:warning("timing out, submitting receipts @ ~p", [_Hash]),
             self() ! submit,
-            {next_state, submitting, Data#data{receiving_timeout=?RECEIVING_TIMEOUT}}
+            {next_state, submitting, save_data(Data#data{state=submitting, receiving_timeout=?RECEIVING_TIMEOUT})}
     end;
 receiving(info, {blockchain_event, {add_block, _Hash, _, _}}, #data{receiving_timeout=T}=Data) ->
     lager:info("got block ~p decreasing timeout", [_Hash]),
-    {keep_state, Data#data{receiving_timeout=T-1}};
+    {keep_state, save_data(Data#data{receiving_timeout=T-1})};
 receiving(cast, {witness, Witness}, #data{responses=Responses0,
                                           packet_hashes=PacketHashes,
                                           blockchain=Chain}=Data) ->
@@ -313,7 +306,7 @@ receiving(cast, {witness, Witness}, #data{responses=Responses0,
                                              true ->
                                                  Responses0
                                          end,
-                            {keep_state, Data#data{responses=Responses1}}
+                            {keep_state, save_data(Data#data{responses=Responses1})}
                     end
             end
     end;
@@ -332,7 +325,7 @@ receiving(cast, {receipt, Receipt}, #data{responses=Responses0, challengees=Chal
                     case maps:get(Gateway, Responses0, undefined) of
                         undefined ->
                             Responses1 = maps:put(Gateway, Receipt, Responses0),
-                            {keep_state, Data#data{responses=Responses1}};
+                            {keep_state, save_data(Data#data{responses=Responses1})};
                         _ ->
                             lager:warning("Already got this receipt ~p for ~p ignoring", [Receipt, Gateway]),
                             {keep_state, Data}
@@ -348,10 +341,6 @@ receiving(cast, {receipt, Receipt}, #data{responses=Responses0, challengees=Chal
 receiving(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 submitting(info, submit, #data{address=Challenger,
                                responses=Responses0,
                                secret=Secret,
@@ -373,24 +362,20 @@ submitting(info, submit, #data{address=Challenger,
     Txn1 = blockchain_txn:sign(Txn0, SigFun),
     ok = blockchain_worker:submit_txn(Txn1),
     lager:info("submitted blockchain_txn_poc_receipts_v1 ~p", [Txn0]),
-    {next_state, waiting, Data#data{receipts_timeout=?RECEIPTS_TIMEOUT}};
+    {next_state, waiting, save_data(Data#data{state=waiting, receipts_timeout=?RECEIPTS_TIMEOUT})};
 submitting(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 waiting(info, {blockchain_event, {add_block, _BlockHash, _, _}}, #data{receipts_timeout=0}=Data) ->
     lager:warning("I have been waiting for ~p blocks abandoning last request", [?RECEIPTS_TIMEOUT]),
-    {next_state, requesting,  Data#data{receipts_timeout=?RECEIPTS_TIMEOUT}};
+    {next_state, requesting,  save_data(Data#data{state=requesting, receipts_timeout=?RECEIPTS_TIMEOUT})};
 waiting(info, {blockchain_event, {add_block, BlockHash, _, _}}, #data{receipts_timeout=Timeout}=Data) ->
     case find_receipts(BlockHash, Data) of
         ok ->
-            {next_state, requesting,  Data#data{receipts_timeout=?RECEIPTS_TIMEOUT}};
+            {next_state, requesting, save_data(Data#data{state=requesting, receipts_timeout=?RECEIPTS_TIMEOUT})};
         {error, _Reason} ->
              lager:info("receipts not found in block ~p : ~p", [BlockHash, _Reason]),
-            {keep_state,  Data#data{receipts_timeout=Timeout-1}}
+            {keep_state, save_data(Data#data{receipts_timeout=Timeout-1})}
     end;
 waiting(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
@@ -399,10 +384,30 @@ waiting(EventType, EventContent, Data) ->
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
+-spec save_data(data()) -> data().
+save_data(#data{base_dir=undefined}=State) ->
+    State;
+save_data(#data{base_dir=BaseDir}=State) ->
+    BinState = erlang:term_to_binary(State),
+    File = filename:join([BaseDir, ?STATE_FILE]),
+    ok = file:write_file(File, BinState),
+    State.
+
+-spec load_data(file:filename_all()) -> {error, any()} | {ok, state(), data()}.
+load_data(BaseDir) ->
+    File = filename:join([BaseDir, ?STATE_FILE]),
+    case file:read_file(File) of
+        {error, _Reason}=Error ->
+            Error;
+        {ok, Binary} ->
+            case erlang:binary_to_term(Binary) of
+                #data{state=State}=Data ->
+                     {ok, State, Data};
+                _ ->
+                    {error, wrong_data}
+            end
+    end.
+
 -spec validate_witness(blockchain_poc_witness_v1:witness(), blockchain_ledger_v1:ledger()) -> boolean().
 validate_witness(Witness, Ledger) ->
     Gateway = blockchain_poc_witness_v1:gateway(Witness),
@@ -421,10 +426,6 @@ validate_witness(Witness, Ledger) ->
             end
     end.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec allow_request(binary(), data()) -> boolean().
 allow_request(BlockHash, #data{blockchain=Blockchain,
                                address=Address,
@@ -460,10 +461,6 @@ allow_request(BlockHash, #data{blockchain=Blockchain,
             end
     end.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec create_request(libp2p_crypto:pubkey_bin(), binary(), blockchain_ledger_v1:ledger()) ->
     {blockchain_txn_poc_request_v1:txn_poc_request(), keys(), binary()}.
 create_request(Address, BlockHash, Ledger) ->
@@ -481,10 +478,6 @@ create_request(Address, BlockHash, Ledger) ->
     {ok, _, SigFun, _ECDHFun} = blockchain_swarm:keys(),
     {blockchain_txn:sign(Tx, SigFun), Keys, Secret}.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec find_request(binary(), data()) -> ok | {error, any()}.
 find_request(BlockHash, #data{blockchain=Blockchain,
                               address=Challenger,
@@ -515,10 +508,6 @@ find_request(BlockHash, #data{blockchain=Blockchain,
             end
     end.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec find_receipts(binary(), data()) -> ok | {error, any()}.
 find_receipts(BlockHash, #data{blockchain=Blockchain,
                                address=Challenger,
@@ -545,13 +534,10 @@ find_receipts(BlockHash, #data{blockchain=Blockchain,
             end
     end.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 handle_event(info, {blockchain_event, {new_chain, NC}},
              #data{address = Address, poc_interval = Delay}) ->
-    {next_state, requesting, #data{blockchain=NC, address=Address, poc_interval=Delay}};
+    {next_state, requesting, save_data(#data{state = requesting, blockchain=NC,
+                                              address=Address, poc_interval=Delay})};
 handle_event(info, {blockchain_event, {add_block, _, _, _}}, Data) ->
     %% suppress the warning here
     {keep_state, Data};
@@ -559,10 +545,6 @@ handle_event(_EventType, _EventContent, Data) ->
     lager:warning("ignoring event [~p] ~p", [_EventType, _EventContent]),
     {keep_state, Data}.
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 send_onion(_P2P, _Onion, 0) ->
     {error, retries_exceeded};
 send_onion(P2P, Onion, Retry) ->

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -419,17 +419,6 @@ basic(_Config) ->
     % 3 previous blocks + 1 block to start process + 1 block with poc req txn
     ok = miner_ct_utils:wait_until(fun() -> {ok, 5} =:= blockchain:height(Chain) end),
 
-    % Passing the random delay
-    ?assertEqual(delaying,  erlang:element(1, sys:get_state(Statem))),
-    ?assertEqual(delaying, erlang:element(6, erlang:element(2, sys:get_state(Statem)))),
-    RandDelay = erlang:element(15, erlang:element(2, sys:get_state(Statem))),
-    lists:foreach(
-        fun(_) ->
-             ok = add_block(Chain, ConsensusMembers, [])
-        end,
-        lists:seq(1, RandDelay+1)
-    ),
-
     % Moving threw targeting and challenging
     ok = miner_ct_utils:wait_until(fun() ->
         case sys:get_state(Statem) of
@@ -583,17 +572,6 @@ restart(_Config) ->
 
     % 3 previous blocks + 1 block to start process + 1 block with poc req txn
     ok = miner_ct_utils:wait_until(fun() -> {ok, 5} =:= blockchain:height(Chain) end),
-
-    % Passing the random delay
-    ?assertEqual(delaying,  erlang:element(1, sys:get_state(Statem0))),
-    ?assertEqual(delaying, erlang:element(6, erlang:element(2, sys:get_state(Statem0)))),
-    RandDelay = erlang:element(15, erlang:element(2, sys:get_state(Statem0))),
-    lists:foreach(
-        fun(_) ->
-             ok = add_block(Chain, ConsensusMembers, [])
-        end,
-        lists:seq(1, RandDelay+1)
-    ),
 
     %% Moving through targeting and challenging
     ok = miner_ct_utils:wait_until(


### PR DESCRIPTION
While working on finishing up #203, which this PR supersedes and is based upon, I decided that there were flaws in the way that delay was being done.  This change rebases the original PR on newer code, then changes the delay mechanism to an interval-proportional probabalistic jitter before the request, rather than before the submission of the receipt.  This allows us to do a few things:
 - simplify the state, as we no longer need to keep the delay counter or save anything between transitions
 - improve jitter performance even in the case of state loss
 - deliver receipts more promptly

This change *should* do a more effective job of spreading challenges out throughout the challenge interval, since it applies the jitter at the chain-anchored start of the process, rather than the state dependent end.