### PR TITLE
add transaction dumping for live debugging

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -23,6 +23,7 @@
    {block_time, 1000},
    {election_interval, 15},
    {dkg_stop_timeout, 15000},
+   {write_failed_txns, true},
    {radio_device, undefined}
   ]}
 ].

--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -428,8 +428,7 @@ write_txn(Reason, Height, Txn) ->
         true ->
             Name = ["/tmp/", io_lib:format("height-~b-hash-~b",
                                            [Height, erlang:phash2(Txn)]), ".txn"],
-            {ok, F} = file:open(Name, [write, binary]),
-            ok = file:write(F, blockchain_txn:serialize(Txn)),
+            ok = file:write_file(Name, blockchain_txn:serialize(Txn)),
             lager:info("~s txn written to disk as ~s", [Reason, Name]),
             ok;
         _ ->


### PR DESCRIPTION
add the ability to dump failing txns on a live node to disk, disabled by default.