### PR TITLE
fix another sync call in the sidecar to break a temporary deadlock

### DIFF
--- a/src/miner_hbbft_sidecar.erl
+++ b/src/miner_hbbft_sidecar.erl
@@ -116,7 +116,9 @@ handle_call({submit, Txn}, From,
                 ok ->
                     case blockchain_txn:absorb(Txn, Chain) of
                         ok ->
-                            catch libp2p_group_relcast:handle_command(Group, Txn),
+                            spawn(fun() ->
+                                          catch libp2p_group_relcast:handle_command(Group, Txn)
+                                  end),
                             {reply, ok, State};
                         Error ->
                             lager:warning("speculative absorb failed for ~p, error: ~p", [Txn, Error]),


### PR DESCRIPTION
wrap the call in a spawn for a quick fix.