### PR TITLE
Bump assumed valid block to 138655

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,9 +22,9 @@
   [
    {honor_assumed_valid, true},
 
-   {assumed_valid_block_height, 131279},
+   {assumed_valid_block_height, 138655},
    {assumed_valid_block_hash,
-    <<137,111,88,159,78,114,190,73,96,48,119,34,248,152,255,63,157,20,94,82,200,244,236,237,209,131,77,36,25,54,200,15>>},
+    <<31,254,105,232,128,247,123,59,86,163,223,180,66,181,158,160,206,153,103,176,201,109,141,196,54,44,231,231,218,71,120,42>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```ubuntu@ip-172-31-63-147:~$ ./connect.sh tall-blonde-condor
Warning: Permanently added '[localhost]:38397' (ECDSA) to the list of known hosts.
helium@localhost's password: 
$ sudo su -
# miner info height
3404		138655
# miner remote_console
Erlang/OTP 22 [erts-10.5] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]Eshell V10.5  (abort with ^G)
(miner@127.0.0.1)1> {ok, Block} = blockchain:get_block(138655, blockchain_worker:blockchain()).
{ok,{blockchain_block_v1_pb,<<65,51,77,64,29,224,90,167,
                              196,21,42,41,199,32,25,14,
                              67,246,252,62,164,230,82,
                              167,163,...>>,
...
(miner@127.0.0.1)2> rp(blockchain_block:hash_block(Block)).
<<31,254,105,232,128,247,123,59,86,163,223,180,66,181,158,
  160,206,153,103,176,201,109,141,196,54,44,231,231,218,
  71,120,42>>
ok
(miner@127.0.0.1)3> rp(blockchain_block:height(Block)).
138655
ok
```