### PR TITLE
Clean up test data and logs on common test success

### DIFF
--- a/test/miner_libp2p_SUITE.erl
+++ b/test/miner_libp2p_SUITE.erl
@@ -32,11 +32,11 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
-init_per_testcase(_TestCase, Config) ->
-    miner_ct_utils:init_per_testcase(_TestCase, Config).
+init_per_testcase(TestCase, Config) ->
+    miner_ct_utils:init_per_testcase(TestCase, Config).
 
-end_per_testcase(_TestCase, Config) ->
-    miner_ct_utils:end_per_testcase(_TestCase, Config).
+end_per_testcase(TestCase, Config) ->
+    miner_ct_utils:end_per_testcase(TestCase, Config).
 
 %% test cases
 listen_addr_test(Config) ->

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -57,7 +57,8 @@ end_per_testcase(basic_test, Config) ->
     case proplists:get_value(tc_status, Config) of
         ok ->
             %% test passed, we can cleanup
-            BaseDir = "data/miner_poc_SUITE/basic_test",
+            PrivDir = proplists:get_value(priv_dir, Config),
+            BaseDir = PrivDir++ "/data_miner_poc_SUITE_basic_test",
             os:cmd("rm -rf "++BaseDir),
             ok;
         _ ->
@@ -69,7 +70,8 @@ end_per_testcase(restart_test, Config) ->
     case proplists:get_value(tc_status, Config) of
         ok ->
             %% test passed, we can cleanup
-            BaseDir = "data/miner_poc_SUITE/restart_test",
+            PrivDir = proplists:get_value(priv_dir, Config),
+            BaseDir = PrivDir ++ "/data_miner_poc_SUITE_restart_test",
             os:cmd("rm -rf "++BaseDir),
             ok;
         _ ->
@@ -113,8 +115,9 @@ poc_dist_v5_partitioned_lying_test(Config) ->
     CommonPOCVars = common_poc_vars(Config),
     run_dist_with_params(poc_dist_v5_partitioned_lying_test, Config, maps:put(?poc_version, 5, CommonPOCVars)).
 
-basic_test(_Config) ->
-    BaseDir = "data/miner_poc_SUITE/basic_test",
+basic_test(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = PrivDir ++ "/data_miner_poc_SUITE_basic_test",
     {PrivKey, PubKey} = new_random_key(ecc_compact),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     ECDHFun = libp2p_crypto:mk_ecdh_fun(PrivKey),
@@ -265,8 +268,9 @@ basic_test(_Config) ->
     ok = gen_statem:stop(Statem),
     ok.
 
-restart_test(_Config) ->
-    BaseDir = "data/miner_poc_SUITE/restart_test",
+restart_test(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = PrivDir ++ "/data_miner_poc_SUITE_restart_test",
     {PrivKey, PubKey} = new_random_key(ecc_compact),
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     ECDHFun = libp2p_crypto:mk_ecdh_fun(PrivKey),


### PR DESCRIPTION
Instead of leaving behind dozens of gigabytes of logs and
blockchain/ledger databases for each test run, if the test suceeds.
delete all the logs and databases at the end of the run.

Additionally use init/end per testcase functions for the poc suite so
that it better matches the other suites and ensures node shutdown after
the test finishes.