### PR TITLE
Bump assumed valid block to 151208

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,9 +22,9 @@
   [
    {honor_assumed_valid, true},
 
-   {assumed_valid_block_height, 138655},
+   {assumed_valid_block_height, 151208},
    {assumed_valid_block_hash,
-    <<31,254,105,232,128,247,123,59,86,163,223,180,66,181,158,160,206,153,103,176,201,109,141,196,54,44,231,231,218,71,120,42>>},
+    <<53,224,97,142,112,108,194,206,31,246,1,242,82,116,43,146,134,107,8,8,130,146,197,75,208,92,198,28,140,70,210,56>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
ubuntu@ip-172-31-63-147:~$ ./connect.sh little-leather-pheasant
Warning: Permanently added '[localhost]:45043' (ECDSA) to the list of known hosts.
helium@localhost's password: 
$ sudo su -
# miner info height
3694		151208
# miner remote_console
Erlang/OTP 22 [erts-10.5] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]

Eshell V10.5  (abort with ^G)
(miner@127.0.0.1)1> {ok, Block} = blockchain:get_block(151208, blockchain_worker:blockchain()).
{ok,{blockchain_block_v1_pb,<<223,113,242,14,135,177,109,
                              199,220,40,134,152,3,17,97,
                              201,61,190,77,211,157,200,
                              169,219,209,...>>,
...
(miner@127.0.0.1)2> rp(blockchain_block:hash_block(Block)).
<<53,224,97,142,112,108,194,206,31,246,1,242,82,116,43,
  146,134,107,8,8,130,146,197,75,208,92,198,28,140,70,210,
  56>>
ok
(miner@127.0.0.1)3> rp(blockchain_block:height(Block)).
151208
ok
```