### PR TITLE
add support for new cli command: info summary

### DIFF
--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -185,15 +185,11 @@ info_p2p_status_usage() ->
      ]
     ].
 
-get_p2p_info() ->
+info_p2p_status(["info", "p2p_status"], [], []) ->
     StatusResults = miner:p2p_status(),
     FormatResult = fun({Name, Result}) ->
                            [{name, Name}, {result, Result}]
                    end,
-    {FormatResult, StatusResults}.
-
-info_p2p_status(["info", "p2p_status"], [], []) ->
-    {FormatResult, StatusResults} = get_p2p_info(),
     [clique_status:table(lists:map(FormatResult, StatusResults))];
 info_p2p_status([_, _, _], [], []) ->
     usage.
@@ -287,7 +283,7 @@ do_info_summary(ErrorCount, ScanRange) ->
         clique_status:table(lists:map(GeneralFormat, GeneralInfo)),
         clique_status:text("\n********************\nMiner P2P Info\n********************\n"),
         hd(info_p2p_status(["info", "p2p_status"], [], [])),
-        clique_status:text("\n********************\nMiner error log entries\n********************\n"),
+        clique_status:text("\n********************\nMiner log errors\n********************\n"),
         clique_status:list(  "***** Transaction related errors *****\n\n", TxnErrorInfo),
         clique_status:list(  "***** POC related errors         *****\n\n", POCErrorInfo),
         clique_status:list(  "***** General errors             *****\n\n", GenErrorInfo)

--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -6,9 +6,14 @@
 
 -behavior(clique_handler).
 
+
 -export([register_cli/0]).
 
 -export([get_info/0]).
+
+
+-define(DEFAULT_LOG_HIT_COUNT, "5").                                                        %% the default number of error log hits to return as part of info summary
+-define(DEFAULT_LOG_SCAN_RANGE, "500").                                                     %% the default number of error log entries to scan as part of info summary
 
 register_cli() ->
     register_all_usage(),
@@ -214,12 +219,13 @@ info_summary_usage() ->
     [["info", "summary"],
      ["info summary \n\n",
       "  Get a collection of key data points for this miner.\n\n"
-      "  Also returns the last 5 error log entries across 3 categories: Transactions, POCs and Other errors.  By default the latest 500 log entries are scanned and the most recent 5 hits for each category returned\n\n"
+      "  Also returns the last " ++ ?DEFAULT_LOG_HIT_COUNT ++ " error log entries across 3 categories: Transactions, POCs and Other errors.\n"
+      "  By default the latest " ++ ?DEFAULT_LOG_SCAN_RANGE ++ " log entries are scanned and the most recent " ++ ?DEFAULT_LOG_HIT_COUNT ++ " hits for each category returned\n\n"
       "Options\n\n"
       "  -e, --error_count <count> "
-      "    Set the count of log entries to return per category ( default=5 )\n"
+      "    Set the count of log entries to return per category)\n"
       "  -s, --scan_range <range> "
-      "    Set the maximum number of log entries to scan ( default=500 )\n\n"
+      "    Set the maximum number of log entries to scan\n\n"
 
      ]
     ].
@@ -268,8 +274,8 @@ get_summary_info(ErrorCount, ScanRange)->
     {GeneralInfo, POCErrors, TxnErrors, GenErrors}.
 
 info_summary(["info", "summary"], _Keys, Flags) ->
-    ErrorCount = proplists:get_value(error_count, Flags, "5"),
-    ScanRange = proplists:get_value(scan_range, Flags, "500"),
+    ErrorCount = proplists:get_value(error_count, Flags, ?DEFAULT_LOG_HIT_COUNT),
+    ScanRange = proplists:get_value(scan_range, Flags, ?DEFAULT_LOG_SCAN_RANGE),
     do_info_summary(ErrorCount, ScanRange).
 
 do_info_summary(ErrorCount, ScanRange) ->

--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -24,7 +24,8 @@ register_all_usage() ->
                    info_in_consensus_usage(),
                    info_name_usage(),
                    info_block_age_usage(),
-                   info_p2p_status_usage()
+                   info_p2p_status_usage(),
+                   info_summary_usage()
                   ]).
 
 register_all_cmds() ->
@@ -37,7 +38,8 @@ register_all_cmds() ->
                    info_in_consensus_cmd(),
                    info_name_cmd(),
                    info_block_age_cmd(),
-                   info_p2p_status_cmd()
+                   info_p2p_status_cmd(),
+                   info_summary_cmd()
                   ]).
 %%
 %% info
@@ -51,6 +53,7 @@ info_usage() ->
       "  name - Shows the name of this miner.\n"
       "  block_age - Get age of the latest block in the chain, in seconds.\n"
       "  p2p_status - Shows key peer connectivity status of this miner.\n"
+      "  summary - Get a collection of key data points for this miner.\n"
      ]
     ].
 
@@ -182,11 +185,157 @@ info_p2p_status_usage() ->
      ]
     ].
 
-info_p2p_status(["info", "p2p_status"], [], []) ->
+get_p2p_info() ->
     StatusResults = miner:p2p_status(),
     FormatResult = fun({Name, Result}) ->
                            [{name, Name}, {result, Result}]
                    end,
+    {FormatResult, StatusResults}.
+
+info_p2p_status(["info", "p2p_status"], [], []) ->
+    {FormatResult, StatusResults} = get_p2p_info(),
     [clique_status:table(lists:map(FormatResult, StatusResults))];
 info_p2p_status([_, _, _], [], []) ->
     usage.
+
+
+%%
+%% info summary
+%%
+
+info_summary_cmd() ->
+    [
+     [["info", "summary"], [], [], fun info_summary/3],
+     [["info", "summary"], [],
+      [{error_count, [  {shortname, "e"},
+                        {longname, "error_count"}]}
+      ], fun info_summary/3]
+    ].
+
+info_summary_usage() ->
+    [["info", "summary"],
+     ["info summary \n\n",
+      "  Get a collection of key data points for this miner.\n\n"
+      "  Included is the last 5 error log entries for 3 categories: Transactions, POCs and Other errors\n\n"
+      "Options\n\n"
+      "  -e, --error_count <count> "
+      "    Override the default count of 5 log entries per category\n\n"
+     ]
+    ].
+
+get_summary_info(ErrorCount)->
+    PubKey = blockchain_swarm:pubkey_bin(),
+    {ok, MinerName} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(PubKey)),
+    {ok, Macs} = get_mac_addrs(),
+    BlockAge = miner:block_age(),
+    Uptime = get_uptime(),
+    {ok, POCErrors, TxnErrors, GenErrors} = get_log_errors(ErrorCount),
+
+    Chain = blockchain_worker:blockchain(),
+    {ok, Height} = blockchain:height(Chain),
+    {ok, SyncHeight} = blockchain:sync_height(Chain),
+    {ok, HeadBlock} = blockchain:head_block(Chain),
+    {Epoch, _} = blockchain_block_v1:election_info(HeadBlock),
+    SyncHeight0 = format_sync_height(SyncHeight, Height),
+
+    Swarm = blockchain_swarm:swarm(),
+    Peerbook = libp2p_swarm:peerbook(Swarm),
+    PeerBookEntryCount = length(libp2p_peerbook:values(Peerbook)),
+
+    FirmwareVersion = get_firmware_version(),
+
+    GWInfo = get_gateway_info(Chain, PubKey),
+
+    GeneralInfo =
+        [   {"miner name", MinerName},
+            {"mac addresses", Macs},
+            {"block age", BlockAge},
+            {"epoch", Epoch},
+            {"height", Height},
+            {"sync height", SyncHeight0},
+            {"uptime", Uptime},
+            {"peer book size", PeerBookEntryCount },
+            {"firmware version", FirmwareVersion},
+            {"gateway details", GWInfo}
+        ],
+    {GeneralInfo, POCErrors, TxnErrors, GenErrors}.
+
+info_summary(["info", "summary"], [], []) ->
+    do_info_summary("5");
+info_summary(["info", "summary"], _Keys, [{error_count, Count}]) ->
+    do_info_summary(Count);
+info_summary(_CmdBase, _Keys, _Flags) ->
+    usage.
+
+do_info_summary(ErrorCount) ->
+    {GeneralInfo, POCErrorInfo, TxnErrorInfo, GenErrorInfo} = get_summary_info(ErrorCount),
+
+    GeneralFormat =   fun({Name, Result}) ->
+                            [{name, Name}, {result, Result}]
+                      end,
+    [   clique_status:text("\n********************\nMiner General Info\n********************\n"),
+        clique_status:table(lists:map(GeneralFormat, GeneralInfo)),
+        clique_status:text("\n********************\nMiner P2P Info\n********************\n"),
+        hd(info_p2p_status(["info", "p2p_status"], [], [])),
+        clique_status:text("\n********************\nMiner error log entries\n********************\n"),
+        clique_status:list("***** Transaction related errors *****\n\n", TxnErrorInfo),
+        clique_status:list( "***** POC related errors         *****\n\n", POCErrorInfo),
+        clique_status:list( "***** General errors             *****\n\n", GenErrorInfo)
+
+    ].
+
+
+get_mac_addrs()->
+    {ok, IFs} = inet:getifaddrs(),
+    Macs = format_macs_from_interfaces(IFs),
+    {ok, Macs}.
+
+get_firmware_version()->
+    os:cmd("cat /etc/lsb_release").  %% TODO - make platform agnostic
+
+get_log_errors(Count)->
+    %% TODO - allow log path to be overridden rather than force script to be run from miner dir
+    %% TODO - finalise grep search terms
+    POCErrors = os:cmd("grep -E \"error.*miner_poc|miner_poc.*error\" ./log/console.log | tail -n" ++ Count),
+    TxnErrors = os:cmd("grep -E \"error.*blockchain_txn|blockchain_txn.*error\" ./log/console.log | tail -n" ++ Count),
+    GenErrors = os:cmd("grep -E \"error\" | grep -Eiv \"blockchain_txn|miner_poc\" ./log/console.log | tail -n" ++ Count),
+    {ok, [POCErrors], [TxnErrors], [GenErrors]}.
+
+get_uptime()->
+    {UpTimeMS, _} = statistics(wall_clock),
+    UpTimeSec = (UpTimeMS div 1000) rem 1000000,
+    DaysTime = calendar:seconds_to_daystime(UpTimeSec),
+    format_days_time(DaysTime).
+
+get_gateway_info(Chain, PubKey)->
+    Ledger = blockchain:ledger(Chain),
+    case blockchain_ledger_v1:find_gateway_info(PubKey, Ledger) of
+        {error, _} ->
+            "gateway not found in ledger";
+        {ok, {GatewayAddr, Gateway}} ->
+            lists:concat("gateway found in ledger, location: ", GatewayAddr:location(Gateway))
+    end.
+
+format_sync_height(SyncHeight, Height) when SyncHeight == Height ->
+    integer_to_list(SyncHeight);
+format_sync_height(SyncHeight, _Height) ->
+    integer_to_list(SyncHeight) ++ "*".
+
+format_days_time({Days, {H, M, S}}) when Days < 0 ->
+    format_days_time({0, {H, M, S}});
+format_days_time({Days, {H, M, S}})->
+    lists:concat([Days, " Days, ",H, " Hours, ", M, " Minutes, ", S, " Seconds"]).
+
+format_macs_from_interfaces(IFs)->
+    lists:foldl(
+        fun({IFName, Prop}, Acc) ->
+            case proplists:get_value(hwaddr, Prop) of
+                undefined -> Acc;
+                HWAddr -> [IFName ++ " : " ++ format_hwaddr(HWAddr) ++ "\n" | Acc]
+            end
+        end,
+    [], IFs).
+
+format_hwaddr(HWAddr)->
+    HWAddr0 = [integer_to_list(B,16) || B <- HWAddr ],
+    lists:concat(HWAddr0).


### PR DESCRIPTION
Adds support for 'info summary' which returns key data points for a miner.

NOTE: the ticket defined some data points which are not included in this PR:

- Date and block # when gateway was added to chain

We do not have any ready means to determine this data currently but it may be added as a separate ticket.



 ./miner/bin/miner info summary usage
Usage: info summary 

  Get a collection of key data points for this miner.

  Also returns the last 5 error log entries across 3 categories: Transactions, POCs and Other errors.
  By default the latest 500 log entries are scanned and the most recent 5 hits for each category returned

Options

  -e, --error_count <count>     Set the count of log entries to return per category)
  -s, --scan_range <range>     Set the maximum number of log entries to scan





./miner/bin/miner info summary -e5 -s100

********************
Miner General Info
********************

+----------------+------------------------------------------------+
|      name      |                     result                     |
+----------------+------------------------------------------------+
|   miner name   |              short-indigo-hornet               |
| mac addresses  |                en4 : 0E05C686E7                |
|                |              bridge0 : 6A0140C080              |
|                |                en2 : 6A0140C081                |
|                |                en1 : 6A0140C080                |
|                |              awdl0 : 1A73C9346DEA              |
|                |               p2p0 : EBC32BD1E3F               |
|                |               en0 : ACBC32BD1E3F               |
|   block age    |                     158218                     |
|     epoch      |                      4025                      |
|     height     |                     164507                     |
|  sync height   |                     164507                     |
|     uptime     |     0 Days, 0 Hours, 0 Minutes, 44 Seconds     |
| peer book size |                      2363                      |
|firmware version|cat: /etc/lsb_release: No such file or directory|
|gateway details |          gateway not found in ledger           |
+----------------+------------------------------------------------+


********************
Miner P2P Info
********************

+---------+-------+
|  name   |result |
+---------+-------+
|connected|  yes  |
|dialable |  yes  |
|nat_type |unknown|
| height  |164507 |
+---------+-------+


********************
Miner log errors
********************

***** Transaction related errors *****

: 2020-01-08 17:12:15.728 [error] <0.9133.0>@blockchain_txn:absorb_and_commit:305 found invalid transactions: [{blockchain_txn_vars_v1_pb,[{blockchain_var_v1_pb,"poc_typo_fixes","atom",<<"true">>},{blockchain_var_v1_pb,"poc_version","int",<<"6">>}],0,<<48,69,2,32,34,221,215,207,79,246,139,252,54,174,189,227,142,143,253,198,229,72,101,130,35,144,95,120,169,1,84,50,108,251,160,88,2,33,0,163,175,215,210,19,197,159,228,187,229,159,65,25,26,141,13,241,68,5,92,234,33,35,133,216,181,173,7,56,117,184,239>>,<<>>,<<>>,[],[],13}]
2020-01-08 17:12:15.006 [warning] <0.9133.0>@blockchain_txn:validate:222 invalid txn blockchain_txn_vars_v1 : {error,{unknown_var,poc_typo_fixes,true}} / {blockchain_txn_vars_v1_pb,
2020-01-08 17:12:15.006 [error] <0.9133.0>@blockchain_txn_vars_v1:is_valid:284 invalid chain var transaction: {blockchain_txn_vars_v1_pb,[{blockchain_var_v1_pb,"poc_typo_fixes","atom",<<"true">>},{blockchain_var_v1_pb,"poc_version","int",<<"6">>}],0,<<48,69,2,32,34,221,215,207,79,246,139,252,54,174,189,227,142,143,253,198,229,72,101,130,35,144,95,120,169,1,84,50,108,251,160,88,2,33,0,163,175,215,210,19,197,159,228,187,229,159,65,25,26,141,13,241,68,5,92,234,33,35,133,216,181,173,7,56,117,184,239>>,<<>>,<<>>,[],[],13} reason {error,{unknown_var,poc_typo_fixes,true}}
2020-01-08 17:12:14.083 [error] <0.9120.0>@blockchain_txn:absorb_and_commit:305 found invalid transactions: [{blockchain_txn_vars_v1_pb,[{blockchain_var_v1_pb,"poc_typo_fixes","atom",<<"true">>},{blockchain_var_v1_pb,"poc_version","int",<<"6">>}],0,<<48,69,2,32,34,221,215,207,79,246,139,252,54,174,189,227,142,143,253,198,229,72,101,130,35,144,95,120,169,1,84,50,108,251,160,88,2,33,0,163,175,215,210,19,197,159,228,187,229,159,65,25,26,141,13,241,68,5,92,234,33,35,133,216,181,173,7,56,117,184,239>>,<<>>,<<>>,[],[],13}]
2020-01-08 17:12:13.349 [warning] <0.9120.0>@blockchain_txn:validate:222 invalid txn blockchain_txn_vars_v1 : {error,{unknown_var,poc_typo_fixes,true}} / {blockchain_txn_vars_v1_pb,

***** POC related errors         *****

: 
***** General errors             *****

: 2020-01-08 17:12:34.550 [warning] <0.1457.0>@libp2p_stream_proxy:dial_back:253 Failed to dial back to undefined at "76.113.141.33" "1038": {error,econnrefused}
2020-01-08 17:12:34.550 [error] <0.1457.0> gen_server <0.1457.0> terminated with reason: econnrefused
2020-01-08 17:12:34.038 [warning] <0.1451.0>@libp2p_stream_proxy:dial_back:253 Failed to dial back to undefined at "76.113.141.33" "1038": {error,econnrefused}
2020-01-08 17:12:34.038 [error] <0.1451.0> gen_server <0.1451.0> terminated with reason: econnrefused
2020-01-08 17:12:33.435 [error] <0.1434.0> gen_server <0.1434.0> terminated with reason: econnrefused