### PR TITLE
properly handle find_gateway_info response

### DIFF
--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -333,12 +333,12 @@ get_uptime()->
 get_gateway_info(Chain, PubKey)->
     Ledger = blockchain:ledger(Chain),
     case blockchain_ledger_v1:find_gateway_info(PubKey, Ledger) of
-        {error, _} ->
-            "gateway not found in ledger";
-        {ok, {GatewayAddr, Gateway}} ->
-            GWLoc = GatewayAddr:location(Gateway),
-            GWOwnAddr = GatewayAddr:owner_address(Gateway),
-            lists:concat(["Gateway location: ", GWLoc, "Ownder address: ", GWOwnAddr])
+        {ok, Gateway} ->
+            GWLoc = blockchain_ledger_gateway_v2:location(Gateway),
+            GWOwnAddr = blockchain_ledger_gateway_v2:owner_address(Gateway),
+            lists:concat(["Gateway location: ", GWLoc, "Ownder address: ", GWOwnAddr]);
+        _ ->
+            "gateway not found in ledger"
     end.
 
 format_sync_height(SyncHeight, Height) when SyncHeight == Height ->


### PR DESCRIPTION
Correct expected return value when a gateway is found.

Treat any non {ok, GW} response as not found rather than restricting it to solely {error, Reason}