### PR TITLE
change tmp dir to be relative from _build dir

### DIFF
--- a/test/miner_dkg_SUITE.erl
+++ b/test/miner_dkg_SUITE.erl
@@ -30,26 +30,26 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_TestCase, Config) ->
-    miner_ct_utils:init_per_testcase(_TestCase, Config).
+    miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config).
 
 end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).
 
 initial_dkg_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
-    Addresses = proplists:get_value(addresses, Config),
+    Miners = ?config(miners, Config),
+    Addresses = ?config(addresses, Config),
     Keys = libp2p_crypto:generate_keys(ecc_compact),
 
     InitialVars = miner_ct_utils:make_vars(Keys, #{}),
     InitialPaymentTransactions = [blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
     InitialTransactions = InitialVars ++ InitialPaymentTransactions,
-    NumConsensusMembers = proplists:get_value(num_consensus_members, Config),
-    Curve = proplists:get_value(dkg_curve, Config),
+    NumConsensusMembers = ?config(num_consensus_members, Config),
+    Curve = ?config(dkg_curve, Config),
 
-    DKGResults = miner_ct_utils:inital_dkg(Miners, InitialTransactions, Addresses, 
+    DKGResults = miner_ct_utils:inital_dkg(Miners, InitialTransactions, Addresses,
                                             NumConsensusMembers, Curve),
     true = lists:all(fun(Res) -> Res == ok end, DKGResults),
-    
+
     {comment, DKGResults}.
 
 

--- a/test/miner_libp2p_SUITE.erl
+++ b/test/miner_libp2p_SUITE.erl
@@ -33,14 +33,14 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(TestCase, Config) ->
-    miner_ct_utils:init_per_testcase(TestCase, Config).
+    miner_ct_utils:init_per_testcase(?MODULE, TestCase, Config).
 
 end_per_testcase(TestCase, Config) ->
     miner_ct_utils:end_per_testcase(TestCase, Config).
 
 %% test cases
 listen_addr_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     ListenAddrs = lists:foldl(fun(Miner, Acc) ->
                                       Swarm = ct_rpc:call(Miner, blockchain_swarm, swarm, []),
                                       LA = ct_rpc:call(Miner, libp2p_swarm, sessions, [Swarm]),
@@ -50,7 +50,7 @@ listen_addr_test(Config) ->
     {comment, ListenAddrs}.
 
 p2p_addr_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     P2PAddrs = lists:foldl(fun(Miner, Acc) ->
                                    Address = ct_rpc:call(Miner, blockchain_swarm, pubkey_bin, []),
                                    P2PAddr = ct_rpc:call(Miner, libp2p_crypto, pubkey_bin_to_p2p, [Address]),

--- a/test/miner_onion_SUITE.erl
+++ b/test/miner_onion_SUITE.erl
@@ -35,7 +35,7 @@ all() ->
 %% @doc
 %% @end
 %%--------------------------------------------------------------------
-basic(_Config) ->
+basic(Config) ->
     application:ensure_all_started(lager),
 
     {ok, Sock} = gen_udp:open(0, [{active, false}, binary, {reuseaddr, true}]),
@@ -64,8 +64,9 @@ basic(_Config) ->
         sig_fun => libp2p_crypto:mk_sig_fun(PrivateKey)
     }),
 
-    TestDir = miner_ct_utils:tmp_dir("miner_onion_suite_basic"),
-    Ledger = blockchain_ledger_v1:new(TestDir),
+    BaseDir = ?config(base_dir, Config),
+    Ledger = blockchain_ledger_v1:new(BaseDir),
+
     BlockHash = crypto:strong_rand_bytes(32),
     Data1 = <<1, 2>>,
     Data2 = <<3, 4>>,

--- a/test/miner_payment_txn_SUITE.erl
+++ b/test/miner_payment_txn_SUITE.erl
@@ -33,18 +33,18 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_TestCase, Config0) ->
-    Config = miner_ct_utils:init_per_testcase(_TestCase, Config0),
-    Miners = proplists:get_value(miners, Config),
-    Addresses = proplists:get_value(addresses, Config),
+    Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    Miners = ?config(miners, Config),
+    Addresses = ?config(addresses, Config),
     InitialPaymentTransactions = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
     AddGwTxns = [blockchain_txn_gen_gateway_v1:new(Addr, Addr, h3:from_geo({37.780586, -122.469470}, 13), 0)
                  || Addr <- Addresses],
 
-    NumConsensusMembers = proplists:get_value(num_consensus_members, Config),
-    BlockTime = proplists:get_value(block_time, Config),
-    BatchSize = proplists:get_value(batch_size, Config),
-    Curve = proplists:get_value(dkg_curve, Config),
-    %% VarCommitInterval = proplists:get_value(var_commit_interval, Config),
+    NumConsensusMembers = ?config(num_consensus_members, Config),
+    BlockTime = ?config(block_time, Config),
+    BatchSize = ?config(batch_size, Config),
+    Curve = ?config(dkg_curve, Config),
+    %% VarCommitInterval = ?config(var_commit_interval, Config),
 
     Keys = libp2p_crypto:generate_keys(ecc_compact),
 
@@ -76,8 +76,8 @@ end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).
 
 single_payment_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
-    ConsensusMiners = proplists:get_value(consensus_miners, Config),
+    Miners = ?config(miners, Config),
+    ConsensusMiners = ?config(consensus_miners, Config),
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = ct_rpc:call(Payee, blockchain_swarm, pubkey_bin, []),
@@ -153,7 +153,7 @@ single_payment_test(Config) ->
     ok.
 
 self_payment_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = PayerAddr,

--- a/test/miner_reward_SUITE.erl
+++ b/test/miner_reward_SUITE.erl
@@ -31,18 +31,18 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_TestCase, Config0) ->
-    Config = miner_ct_utils:init_per_testcase(_TestCase, Config0),
-    Miners = proplists:get_value(miners, Config),
-    Addresses = proplists:get_value(addresses, Config),
+    Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    Miners = ?config(miners, Config),
+    Addresses = ?config(addresses, Config),
     InitialCoinbaseTxns = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
     AddGwTxns = [blockchain_txn_gen_gateway_v1:new(Addr, Addr, h3:from_geo({37.780586, -122.469470}, 13), 0)
                  || Addr <- Addresses],
 
-    NumConsensusMembers = proplists:get_value(num_consensus_members, Config),
-    BlockTime = proplists:get_value(block_time, Config),
+    NumConsensusMembers = ?config(num_consensus_members, Config),
+    BlockTime = ?config(block_time, Config),
     Interval = 5,
-    BatchSize = proplists:get_value(batch_size, Config),
-    Curve = proplists:get_value(dkg_curve, Config),
+    BatchSize = ?config(batch_size, Config),
+    Curve = ?config(dkg_curve, Config),
 
     Keys = libp2p_crypto:generate_keys(ecc_compact),
 
@@ -78,9 +78,9 @@ end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).
 
 basic_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
-    ConsensusMiners = proplists:get_value(consensus_miners, Config),
-    NonConsensusMiners = proplists:get_value(non_consensus_miners, Config),
+    Miners = ?config(miners, Config),
+    ConsensusMiners = ?config(consensus_miners, Config),
+    NonConsensusMiners = ?config(non_consensus_miners, Config),
 
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),

--- a/test/miner_router_SUITE.erl
+++ b/test/miner_router_SUITE.erl
@@ -31,20 +31,20 @@
 all() -> [basic].
 
 init_per_testcase(_TestCase, Config0) ->
-    Config = miner_ct_utils:init_per_testcase(_TestCase, Config0),
-    Miners = proplists:get_value(miners, Config),
-    Addresses = proplists:get_value(addresses, Config),
+    Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    Miners = ?config(miners, Config),
+    Addresses = ?config(addresses, Config),
     InitialPaymentTransactions = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
     InitialDCTransactions = [ blockchain_txn_dc_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
     AddGwTxns = [blockchain_txn_gen_gateway_v1:new(Addr, Addr, h3:from_geo({37.780586, -122.469470}, 13), 0)
                  || Addr <- Addresses],
 
-    NumConsensusMembers = proplists:get_value(num_consensus_members, Config),
-    BlockTime = proplists:get_value(block_time, Config),
-    Interval = proplists:get_value(election_interval, Config),
-    BatchSize = proplists:get_value(batch_size, Config),
-    Curve = proplists:get_value(dkg_curve, Config),
-    %% VarCommitInterval = proplists:get_value(var_commit_interval, Config),
+    NumConsensusMembers = ?config(num_consensus_members, Config),
+    BlockTime = ?config(block_time, Config),
+    Interval = ?config(election_interval, Config),
+    BatchSize = ?config(batch_size, Config),
+    Curve = ?config(dkg_curve, Config),
+    %% VarCommitInterval = ?config(var_commit_interval, Config),
 
     Keys = libp2p_crypto:generate_keys(ecc_compact),
 
@@ -86,7 +86,7 @@ end_per_testcase(_TestCase, Config) ->
 %% @end
 %%--------------------------------------------------------------------
 basic(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Owner| _Tail] = Miners,
     OwnerPubKeyBin = ct_rpc:call(Owner, blockchain_swarm, pubkey_bin, []),
 

--- a/test/miner_txn_bundle_SUITE.erl
+++ b/test/miner_txn_bundle_SUITE.erl
@@ -53,9 +53,9 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_TestCase, Config0) ->
-    Config = miner_ct_utils:init_per_testcase(_TestCase, Config0),
-    Miners = proplists:get_value(miners, Config),
-    Addresses = proplists:get_value(addresses, Config),
+    Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    Miners = ?config(miners, Config),
+    Addresses = ?config(addresses, Config),
     Balance = 5000,
     InitialCoinbaseTxns = [ blockchain_txn_coinbase_v1:new(Addr, Balance) || Addr <- Addresses],
     CoinbaseDCTxns = [blockchain_txn_dc_coinbase_v1:new(Addr, Balance) || Addr <- Addresses],
@@ -63,12 +63,12 @@ init_per_testcase(_TestCase, Config0) ->
     AddGwTxns = [blockchain_txn_gen_gateway_v1:new(Addr, Addr, h3:from_geo({37.780586, -122.469470}, 13), 0)
                  || Addr <- Addresses],
 
-    NumConsensusMembers= proplists:get_value(num_consensus_members, Config),
-    BlockTime = proplists:get_value(block_time, Config),
+    NumConsensusMembers= ?config(num_consensus_members, Config),
+    BlockTime = ?config(block_time, Config),
     %% Don't want an election to happen, messes up checking the balances later
     Interval = 100,
-    BatchSize = proplists:get_value(batch_size, Config),
-    Curve = proplists:get_value(dkg_curve, Config),
+    BatchSize = ?config(batch_size, Config),
+    Curve = ?config(dkg_curve, Config),
 
     Keys = libp2p_crypto:generate_keys(ecc_compact),
 
@@ -96,7 +96,7 @@ end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).
 
 basic_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = ct_rpc:call(Payee, blockchain_swarm, pubkey_bin, []),
@@ -135,7 +135,7 @@ basic_test(Config) ->
     ok.
 
 negative_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = ct_rpc:call(Payee, blockchain_swarm, pubkey_bin, []),
@@ -179,7 +179,7 @@ negative_test(Config) ->
     ok.
 
 double_spend_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Payer, Payee, Other | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = ct_rpc:call(Payee, blockchain_swarm, pubkey_bin, []),
@@ -230,7 +230,7 @@ successive_test(Config) ->
     %% A -> B -> C
     %% A -> B 5000
     %% B -> C 10000
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA, MinerB, MinerC | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
     MinerBPubkeyBin = ct_rpc:call(MinerB, blockchain_swarm, pubkey_bin, []),
@@ -281,7 +281,7 @@ invalid_successive_test(Config) ->
     %% A -> B -> C
     %% A -> B 4000
     %% B -> C 10000 <-- this is invalid
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA, MinerB, MinerC | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
     MinerBPubkeyBin = ct_rpc:call(MinerB, blockchain_swarm, pubkey_bin, []),
@@ -331,7 +331,7 @@ single_payer_test(Config) ->
     %% Test a bundled payment from single payer
     %% A -> B 2000
     %% A -> C 3000
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA, MinerB, MinerC | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
     MinerBPubkeyBin = ct_rpc:call(MinerB, blockchain_swarm, pubkey_bin, []),
@@ -381,7 +381,7 @@ single_payer_invalid_test(Config) ->
     %% Test a bundled payment from single payer
     %% A -> B 2000
     %% A -> C 4000
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA, MinerB, MinerC | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
     MinerBPubkeyBin = ct_rpc:call(MinerB, blockchain_swarm, pubkey_bin, []),
@@ -433,7 +433,7 @@ full_circle_test(Config) ->
     %% A -> B -> C
     %% A -> B 5000
     %% B -> C 10000
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA, MinerB, MinerC | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
     MinerBPubkeyBin = ct_rpc:call(MinerB, blockchain_swarm, pubkey_bin, []),
@@ -491,7 +491,7 @@ full_circle_test(Config) ->
 add_assert_test(Config) ->
     %% Test add + assert in a bundled txn
     %% A -> [add_gateway, assert_location]
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
 
@@ -539,7 +539,7 @@ add_assert_test(Config) ->
 invalid_add_assert_test(Config) ->
     %% Test add + assert in a bundled txn
     %% A -> [add_gateway, assert_location]
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [MinerA | _Tail] = Miners,
     MinerAPubkeyBin = ct_rpc:call(MinerA, blockchain_swarm, pubkey_bin, []),
 
@@ -580,7 +580,7 @@ invalid_add_assert_test(Config) ->
     ok.
 
 single_txn_bundle_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = ct_rpc:call(Payee, blockchain_swarm, pubkey_bin, []),
@@ -616,7 +616,7 @@ single_txn_bundle_test(Config) ->
     ok.
 
 bundleception_test(Config) ->
-    Miners = proplists:get_value(miners, Config),
+    Miners = ?config(miners, Config),
     [Payer, Payee | _Tail] = Miners,
     PayerAddr = ct_rpc:call(Payer, blockchain_swarm, pubkey_bin, []),
     PayeeAddr = ct_rpc:call(Payee, blockchain_swarm, pubkey_bin, []),


### PR DESCRIPTION
Changes include:

1. Force common test to use priv_dir as the base scratch location. All logs, assets, artefacts such as DBs etc will be written relative to here.  Base dir data is included in the Config prop.   Each test has its own private scratch per run using a combination of the test module plus test case as the naming convention.

2.  Tidied up CTs to use ?config macro when accessing data from Config prop

2.  Whilst none of the existing eunit tests use the tmp_dir, i have modified this to be consistent with both libp2p and blockchain-core.  Tmp dir location for unit tests is now relative to '_build' dir.   Function also included to cleanup tmp dir assets