### PR TITLE
enable targetting to continue in the event of a crash 

### DIFF
--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -476,6 +476,191 @@ restart_test(Config) ->
     ok.
 
 
+restart_per_state_test(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    BaseDir = PrivDir ++ "/data_miner_poc_SUITE_restart_test",
+    {PrivKey, PubKey} = new_random_key(ecc_compact),
+    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
+    ECDHFun = libp2p_crypto:mk_ecdh_fun(PrivKey),
+    Opts = [
+        {key, {PubKey, SigFun, ECDHFun}},
+        {seed_nodes, []},
+        {port, 0},
+        {num_consensus_members, 7},
+        {base_dir, BaseDir}
+    ],
+    {ok, _Sup} = blockchain_sup:start_link(Opts),
+    ?assert(erlang:is_pid(blockchain_swarm:swarm())),
+
+    % Now add genesis
+    % Generate fake blockchains (just the keys)
+    RandomKeys = miner_ct_utils:generate_keys(6),
+    Address = blockchain_swarm:pubkey_bin(),
+    ConsensusMembers = [
+        {Address, {PubKey, PrivKey, libp2p_crypto:mk_sig_fun(PrivKey)}}
+    ] ++ RandomKeys,
+
+    % Create genesis block
+    Balance = 5000,
+    ConbaseTxns = [blockchain_txn_coinbase_v1:new(Addr, Balance)
+                     || {Addr, _} <- ConsensusMembers],
+    ConbaseDCTxns = [blockchain_txn_dc_coinbase_v1:new(Addr, Balance)
+                     || {Addr, _} <- ConsensusMembers],
+    GenConsensusGroupTx = blockchain_txn_consensus_group_v1:new([Addr || {Addr, _} <- ConsensusMembers], <<>>, 1, 0),
+    VarsKeys = libp2p_crypto:generate_keys(ecc_compact),
+    VarsTx = miner_ct_utils:make_vars(VarsKeys, #{?poc_challenge_interval => 20}),
+
+    Txs = ConbaseTxns ++ ConbaseDCTxns ++ [GenConsensusGroupTx] ++ VarsTx,
+    GenesisBlock = blockchain_block_v1:new_genesis_block(Txs),
+    ok = blockchain_worker:integrate_genesis_block(GenesisBlock),
+
+    Chain = blockchain_worker:blockchain(),
+    {ok, HeadBlock} = blockchain:head_block(Chain),
+
+    ?assertEqual(blockchain_block:hash_block(GenesisBlock), blockchain_block:hash_block(HeadBlock)),
+    ?assertEqual({ok, GenesisBlock}, blockchain:head_block(Chain)),
+    ?assertEqual({ok, blockchain_block:hash_block(GenesisBlock)}, blockchain:genesis_hash(Chain)),
+    ?assertEqual({ok, GenesisBlock}, blockchain:genesis_block(Chain)),
+    ?assertEqual({ok, 1}, blockchain:height(Chain)),
+
+    % All these point are in a line one after the other (except last)
+    LatLongs = [
+        {{37.780586, -122.469471}, {PrivKey, PubKey}},
+        {{37.780959, -122.467496}, miner_ct_utils:new_random_key(ecc_compact)},
+        {{37.78101, -122.465372}, miner_ct_utils:new_random_key(ecc_compact)},
+        {{37.781179, -122.463226}, miner_ct_utils:new_random_key(ecc_compact)},
+        {{37.781281, -122.461038}, miner_ct_utils:new_random_key(ecc_compact)},
+        {{37.781349, -122.458892}, miner_ct_utils:new_random_key(ecc_compact)},
+        {{37.781468, -122.456617}, miner_ct_utils:new_random_key(ecc_compact)},
+        {{37.781637, -122.4543}, miner_ct_utils:new_random_key(ecc_compact)}
+    ],
+
+    % Add a Gateway
+    AddGatewayTxs = build_gateways(LatLongs, {PrivKey, PubKey}),
+    ok = add_block(Chain, ConsensusMembers, AddGatewayTxs),
+
+    true = miner_ct_utils:wait_until(fun() -> {ok, 2} =:= blockchain:height(Chain) end),
+
+    % Assert the Gateways location
+    AssertLocaltionTxns = build_asserts(LatLongs, {PrivKey, PubKey}),
+    ok = add_block(Chain, ConsensusMembers, AssertLocaltionTxns),
+
+    true = miner_ct_utils:wait_until(fun() -> {ok, 3} =:= blockchain:height(Chain) end),
+
+    {ok, Statem0} = miner_poc_statem:start_link(#{delay => 5,
+                                                  base_dir => BaseDir}),
+
+    ?assertEqual(requesting,  erlang:element(1, sys:get_state(Statem0))),
+    ?assertEqual(Chain, erlang:element(3, erlang:element(2, sys:get_state(Statem0)))), % Blockchain is = to Chain
+    ?assertEqual(requesting, erlang:element(6, erlang:element(2, sys:get_state(Statem0)))), % State is requesting
+
+    %% restart the statem and confirm we remain in correct state
+    ok = gen_statem:stop(Statem0),
+    {ok, Statem1} = miner_poc_statem:start_link(#{delay => 5,
+                                                  base_dir => BaseDir}),
+    ?assertEqual(requesting,  erlang:element(1, sys:get_state(Statem1))),
+    ?assertEqual(requesting, erlang:element(6, erlang:element(2, sys:get_state(Statem1)))),
+
+    % Mock submit_txn to actually add the block
+    meck:new(blockchain_worker, [passthrough]),
+    meck:expect(blockchain_worker, submit_txn, fun(Txn) ->
+        add_block(Chain, ConsensusMembers, [Txn])
+    end),
+    meck:new(miner_onion, [passthrough]),
+    meck:expect(miner_onion, dial_framed_stream, fun(_, _, _) ->
+        {ok, self()}
+    end),
+
+    meck:new(miner_onion_handler, [passthrough]),
+    meck:expect(miner_onion_handler, send, fun(Stream, _Onion) ->
+        ?assertEqual(self(), Stream)
+    end),
+
+    meck:new(blockchain_txn_poc_receipts_v1, [passthrough]),
+    meck:expect(blockchain_txn_poc_receipts_v1, is_valid, fun(_, _) -> ok end),
+
+    ?assertEqual(5, erlang:element(14, erlang:element(2, sys:get_state(Statem0)))),
+
+    % Add some block to start process
+    ok = add_block(Chain, ConsensusMembers, []),
+
+    %% restart the statem and confirm we remain in correct state
+    ok = gen_statem:stop(Statem0),
+    {ok, Statem1} = miner_poc_statem:start_link(#{delay => 5,
+                                                  base_dir => BaseDir}),
+    ?assertEqual(mining,  erlang:element(1, sys:get_state(Statem1))),
+    ?assertEqual(mining, erlang:element(6, erlang:element(2, sys:get_state(Statem1)))),
+
+    % 3 previous blocks + 1 block to start process + 1 block with poc req txn
+    true = miner_ct_utils:wait_until(fun() -> {ok, 5} =:= blockchain:height(Chain) end),
+
+    %% Moving through targeting and challenging
+    true = miner_ct_utils:wait_until(
+           fun() ->
+                   case sys:get_state(Statem0) of
+                       {receiving, _} -> true;
+                       _Other ->
+                           ct:pal("other state ~p", [_Other]),
+                           false
+                   end
+           end),
+
+    % KILLING STATEM AND RESTARTING
+    ok = gen_statem:stop(Statem0),
+    {ok, Statem1} = miner_poc_statem:start_link(#{delay => 5,
+                                                  base_dir => BaseDir}),
+
+    ?assertEqual(receiving,  erlang:element(1, sys:get_state(Statem1))),
+    ?assertEqual(receiving, erlang:element(6, erlang:element(2, sys:get_state(Statem1)))),
+
+    % Send 7 receipts and add blocks to pass timeout
+    ?assertEqual(0, maps:size(erlang:element(11, erlang:element(2, sys:get_state(Statem1))))),
+    Challengees = erlang:element(9, erlang:element(2, sys:get_state(Statem1))),
+    ok = send_receipts(LatLongs, Challengees),
+    timer:sleep(100),
+
+    ?assertEqual(receiving,  erlang:element(1, sys:get_state(Statem1))),
+    ?assertEqual(receiving, erlang:element(6, erlang:element(2, sys:get_state(Statem1)))),
+    ?assert(maps:size(erlang:element(11, erlang:element(2, sys:get_state(Statem1)))) > 0), % Get reponses
+
+    % Passing receiving_timeout
+    lists:foreach(
+        fun(_) ->
+            ok = add_block(Chain, ConsensusMembers, []),
+            timer:sleep(100)
+        end,
+        lists:seq(1, 10)
+    ),
+
+    ?assertEqual(receiving,  erlang:element(1, sys:get_state(Statem1))),
+    ?assertEqual(0, erlang:element(12, erlang:element(2, sys:get_state(Statem1)))), % Get receiving_timeout
+    ok = add_block(Chain, ConsensusMembers, []),
+
+    true = miner_ct_utils:wait_until(
+           fun() ->
+                   case sys:get_state(Statem1) of
+                       {waiting, _} -> true;
+                       {submitting, _} -> true;
+                       {requesting, _} -> true;
+                       {_Other, _} ->
+                           ct:pal("other state ~p", [_Other]),
+                           false
+                   end
+           end),
+
+    ?assert(meck:validate(blockchain_worker)),
+    meck:unload(blockchain_worker),
+    ?assert(meck:validate(miner_onion)),
+    meck:unload(miner_onion),
+    ?assert(meck:validate(miner_onion_handler)),
+    meck:unload(miner_onion_handler),
+    ?assert(meck:validate(blockchain_txn_poc_receipts_v1)),
+    meck:unload(blockchain_txn_poc_receipts_v1),
+
+    ok = gen_statem:stop(Statem1),
+    ok.
+
+
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------


### PR DESCRIPTION
Also fixes bug with poc_starts counter not being written to state file