### PR TITLE
handle empty poc statem files and also those with a badly encoded term

### DIFF
--- a/src/poc/miner_poc_statem.erl
+++ b/src/poc/miner_poc_statem.erl
@@ -521,35 +521,41 @@ load_data(BaseDir) ->
     try file:read_file(File) of
         {error, _Reason}=Error ->
             Error;
+        {ok, <<>>} ->
+            {error, empty_file};
         {ok, Binary} ->
-            case erlang:binary_to_term(Binary) of
-                #{state := State,
-                  secret := Secret,
-                  onion_keys := Keys,
-                  challengees := Challengees,
-                  packet_hashes := PacketHashes,
-                  responses := Responses,
-                  receiving_timeout := RecTimeout,
-                  poc_hash := PoCHash,
-                  mining_timeout := MiningTimeout,
-                  retry := Retry,
-                  receipts_timeout := ReceiptTimeout} ->
-                    {ok, State,
-                     #data{base_dir = BaseDir,
-                           state = State,
-                           secret = Secret,
-                           onion_keys = Keys,
-                           challengees = Challengees,
-                           packet_hashes = PacketHashes,
-                           responses = Responses,
-                           receiving_timeout = RecTimeout,
-                           poc_hash = PoCHash,
-                           mining_timeout = MiningTimeout,
-                           retry = Retry,
-                           receipts_timeout = ReceiptTimeout}};
-                _ ->
-                    {error, wrong_data}
+            try erlang:binary_to_term(Binary) of
+                    #{state := State,
+                      secret := Secret,
+                      onion_keys := Keys,
+                      challengees := Challengees,
+                      packet_hashes := PacketHashes,
+                      responses := Responses,
+                      receiving_timeout := RecTimeout,
+                      poc_hash := PoCHash,
+                      mining_timeout := MiningTimeout,
+                      retry := Retry,
+                      receipts_timeout := ReceiptTimeout} ->
+                        {ok, State,
+                         #data{base_dir = BaseDir,
+                               state = State,
+                               secret = Secret,
+                               onion_keys = Keys,
+                               challengees = Challengees,
+                               packet_hashes = PacketHashes,
+                               responses = Responses,
+                               receiving_timeout = RecTimeout,
+                               poc_hash = PoCHash,
+                               mining_timeout = MiningTimeout,
+                               retry = Retry,
+                               receipts_timeout = ReceiptTimeout}};
+                    _ ->
+                        {error, wrong_data}
+            catch
+                error:bararg ->
+                    {error, bad_term}
             end
+
     catch _:_ ->
             {error, read_error}
     end.


### PR DESCRIPTION
We hit a crash bug on a hotspot which resulted from an empty poc statem file being present on the file system.

This resulted in the binary_to_term on the empty binary crashing with a bararg error

This PR appropriately handles the empty file and goes further to accommodates a file which may have a badly encoded term ( such as if the file was manually edited or the system crashed out mid writing )