### PR TITLE
add tests to cover statem init with bad state file

### DIFF
--- a/src/poc/miner_poc_statem.erl
+++ b/src/poc/miner_poc_statem.erl
@@ -563,7 +563,7 @@ load_data(BaseDir) ->
                     _ ->
                         {error, wrong_data}
             catch
-                error:bararg ->
+                error:badarg ->
                     {error, bad_term}
             end
 


### PR DESCRIPTION
NOTE: IGNORE THIS PR UNTIL AFTER https://github.com/helium/miner/pull/309 is MERGED

Provides test coverage of the statem init when the saved state file is empty, contains a bad term and then finally with an unsupported state.

Also fixes a typo identified by the test in the statem when loading the state file containing a bad term