### PR TITLE
notify the miner that we're out

### DIFF
--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -66,9 +66,11 @@ handle_command({set_buf, Buf}, State) ->
     {reply, ok, [], State#state{hbbft = hbbft:buf(Buf, State#state.hbbft)}};
 handle_command(stop, State) ->
     %% TODO add ignore support for this four tuple to use ignore
+    lager:info("stop called without timeout"),
     {reply, ok, [{stop, timer:minutes(1)}], State};
 handle_command({stop, Timeout}, State) ->
     %% TODO add ignore support for this four tuple to use ignore
+    lager:info("stop called with timeout: ~p", [Timeout]),
     {reply, ok, [{stop, Timeout}], State};
 handle_command({status, Ref, Worker}, State) ->
     Map = hbbft:status(State#state.hbbft),

--- a/src/miner_consensus_mgr.erl
+++ b/src/miner_consensus_mgr.erl
@@ -450,10 +450,12 @@ handle_info({blockchain_event, {add_block, Hash, Sync, _Ledger}},
                                     %% we're not in
                                     error ->
                                         stop_group(State2#state.active_group),
+                                        miner:remove_consensus(),
                                         miner_hbbft_sidecar:set_group(undefined),
                                         State2#state{active_group = undefined};
                                     {ok, out} ->
                                         stop_group(State2#state.active_group),
+                                        miner:remove_consensus(),
                                         miner_hbbft_sidecar:set_group(undefined),
                                         State2#state{current_dkgs = maps:remove(EID, State2#state.current_dkgs),
                                                      active_group = undefined};


### PR DESCRIPTION
this seems to have gotten lost in my latest refactor of this stuff.  With this, we'll bad_sup instead of properly signaling that we're not in the group anymore.  This should remove some confusion as to when we're getting a bad_sup for other reasons, and when we've just exited the group.