### PR TITLE
Bump assumed valid block to 196777

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,7 +22,7 @@
   [
    {honor_assumed_valid, true},
 
-   {assumed_valid_block_height, 186622},
+   {assumed_valid_block_height, 196777},
    {assumed_valid_block_hash,
     <<104,251,74,43,120,160,101,163,179,105,182,101,206,26,73,93,114,15,239,168,203,1,77,53,201,67,53,35,96,157,144,243>>},
    {port, 44158},

--- a/config/sys.config
+++ b/config/sys.config
@@ -24,7 +24,7 @@
 
    {assumed_valid_block_height, 186622},
    {assumed_valid_block_hash,
-    <<137,212,10,251,65,152,89,56,128,142,238,92,55,60,40,22,118,60,140,19,101,229,254,170,202,87,13,240,173,129,51,215>>},
+    <<104,251,74,43,120,160,101,163,179,105,182,101,206,26,73,93,114,15,239,168,203,1,77,53,201,67,53,35,96,157,144,243>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
(miner@127.0.0.1)2> rp(blockchain_block:hash_block(Block)).
<<104,251,74,43,120,160,101,163,179,105,182,101,206,26,73,
  93,114,15,239,168,203,1,77,53,201,67,53,35,96,157,144,
  243>>
ok
(miner@127.0.0.1)3> rp(blockchain_block:height(Block)).
196777
ok
```