### PR TITLE
Add print_keys script

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -66,6 +66,7 @@
                              {copy, "scripts/extensions/info", "bin/extensions/info"},
                              {copy, "scripts/extensions/dkg", "bin/extensions/dkg"},
                              {copy, "scripts/extensions/authorize", "bin/extensions/authorize"},
+                             {template, "scripts/extensions/print_keys", "bin/extensions/print_keys"},
                              {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
                              {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
                              {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
@@ -93,7 +94,8 @@
                              {txn, "extensions/txn"},
                              {dkg, "extensions/dkg"},
                              {authorize, "extensions/authorize"},
-                             {repair, "extensions/repair"}
+                             {repair, "extensions/repair"},
+                             {print_keys, "extensions/print_keys"}
                             ]},
                            {dev_mode, true},
                            {include_erts, false}]}]
@@ -111,6 +113,7 @@
                              {copy, "scripts/extensions/info", "bin/extensions/info"},
                              {copy, "scripts/extensions/dkg", "bin/extensions/dkg"},
                              {copy, "scripts/extensions/authorize", "bin/extensions/authorize"},
+                             {template, "scripts/extensions/print_keys", "bin/extensions/print_keys"},
                              {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
                              {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
                              {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
@@ -169,6 +172,7 @@
                                        {copy, "scripts/extensions/info", "bin/extensions/info"},
                                        {copy, "scripts/extensions/dkg", "bin/extensions/dkg"},
                                        {copy, "scripts/extensions/authorize", "bin/extensions/authorize"},
+                                       {template, "scripts/extensions/print_keys", "bin/extensions/print_keys"},
                                        {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
                                        {copy, "./_build/default/lib/blockchain/scripts/extensions/ledger", "bin/extensions/ledger"},
                                        {copy, "./_build/default/lib/blockchain/scripts/extensions/trace", "bin/extensions/trace"},
@@ -193,7 +197,8 @@
                                                                 {txn, "extensions/txn"},
                                                                 {dkg, "extensions/dkg"},
                                                                 {authorize, "extensions/authorize"},
-                                                                {repair, "extensions/repair"}
+                                                                {repair, "extensions/repair"},
+                                                                {print_keys, "extensions/print_keys"}
                                                                ]},
                             {include_erts, false}]}]
             },

--- a/scripts/extensions/print_keys
+++ b/scripts/extensions/print_keys
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+erl -pa {{lib_dirs}}/**/ebin -noshell -eval 'miner_keys:print_keys("{{sys_config}}")' -eval 'init:stop()'

--- a/src/miner_ebus.erl
+++ b/src/miner_ebus.erl
@@ -17,8 +17,6 @@
 -define(MINER_INTERFACE, "com.helium.Miner").
 -define(MINER_OBJECT(M), ?MINER_INTERFACE ++ "." ++ M).
 
--define(MINER_MEMBER_PUBKEY, "PubKey").
--define(MINER_MEMBER_ONBOARDING_KEY, "OnboardingKey").
 -define(MINER_MEMBER_ADD_GW, "AddGateway").
 -define(MINER_MEMBER_ASSERT_LOC, "AssertLocation").
 -define(MINER_MEMBER_P2P_STATUS, "P2PStatus").
@@ -47,12 +45,6 @@ init(_Args) ->
     {ok, #state{}}.
 
 
-handle_message(?MINER_OBJECT(?MINER_MEMBER_PUBKEY), _Msg, State=#state{}) ->
-    PubKeyBin = miner:pubkey_bin(),
-    {reply, [string], [libp2p_crypto:bin_to_b58(PubKeyBin)], State};
-handle_message(?MINER_OBJECT(?MINER_MEMBER_ONBOARDING_KEY), _Msg, State=#state{}) ->
-    PubKeyBin = miner:onboarding_key_bin(),
-    {reply, [string], [libp2p_crypto:bin_to_b58(PubKeyBin)], State};
 handle_message(?MINER_OBJECT(?MINER_MEMBER_ADD_GW)=Member, Msg, State=#state{}) ->
     case ebus_message:args(Msg) of
         {ok, [OwnerB58, Fee, StakingFee, PayerB58]} ->

--- a/src/miner_keys.erl
+++ b/src/miner_keys.erl
@@ -1,0 +1,132 @@
+-module(miner_keys).
+
+-export([keys/1, print_keys/1]).
+
+-type key_info() :: #{ pubkey => libp2p_crypto:pubkey(),
+                       key_slot => non_neg_integer() | undefined,
+                       ecdh_fun => libp2p_crypto:ecdh_fun(),
+                       sig_fun => libp2p_crypto:sig_fun(),
+                       onboarding_key => libp2p_crypto:pubkey() | undefined
+                     }.
+-export_type([key_info/0]).
+
+%% @doc Fetch the miner key, onboarding key, keyslot and associated
+%% signing and ecdh functions from either a file (for non-hardware
+%% based hotspots)or the ECC.
+%%
+%% NOTE: Do NOT call this after miner has started since this function
+%% will attempt to communicate directly with the ECC. Use only as part
+%% of startup or other miner-free scripts.
+-spec keys({file, BaseDir::string()} |
+           {ecc, proplists:proplist()}) -> key_info().
+keys({file, BaseDir}) ->
+    SwarmKey = filename:join([BaseDir, "miner", "swarm_key"]),
+    ok = filelib:ensure_dir(SwarmKey),
+    case libp2p_crypto:load_keys(SwarmKey) of
+        {ok, #{secret := PrivKey0, public := PubKey}} ->
+            #{ pubkey => PubKey,
+               key_slot => undefined,
+               ecdh_fun => libp2p_crypto:mk_ecdh_fun(PrivKey0),
+               sig_fun => libp2p_crypto:mk_sig_fun(PrivKey0),
+               onboarding_key => undefined
+             };
+        {error, enoent} ->
+            KeyMap = #{secret := PrivKey0, public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+            ok = libp2p_crypto:save_keys(KeyMap, SwarmKey),
+            #{ pubkey => PubKey,
+               key_slot => undefined,
+               ecdh_fun => libp2p_crypto:mk_ecdh_fun(PrivKey0),
+               sig_fun => libp2p_crypto:mk_sig_fun(PrivKey0),
+               onboarding_key => undefined
+             }
+    end;
+keys({ecc, Props}) when is_list(Props) ->
+    KeySlot0 = proplists:get_value(key_slot, Props, 0),
+    OnboardingKeySlot = proplists:get_value(onboarding_key_slot, Props, 15),
+    %% Create a temporary ecc link to get the public key and
+    %% onboarding keys for the given slots as well as the
+    {ok, ECCPid} = ecc508:start_link(),
+    {ok, PubKey, KeySlot} = get_public_key(ECCPid, KeySlot0),
+    {ok, OnboardingKey} = ecc508:genkey(ECCPid, public, OnboardingKeySlot),
+    %% Stop ephemeral ecc pid
+    ecc508:stop(ECCPid),
+
+    #{ pubkey => PubKey,
+       key_slot => KeySlot,
+       %% The signing and ecdh functions will use an actual
+       %% worker against a named process.
+       ecdh_fun => fun(PublicKey) ->
+                           {ok, Bin} = miner_ecc_worker:ecdh(PublicKey),
+                           Bin
+                   end,
+       sig_fun => fun(Bin) ->
+                          {ok, Sig} = miner_ecc_worker:sign(Bin),
+                          Sig
+                  end,
+       onboarding_key => OnboardingKey
+     }.
+
+
+%% @doc prints the public hotspot and onboadring key in a file:consult
+%% friendly way to stdout. This is used by other services (like
+%% gateway_config) to get read access to the public keys
+print_keys(ConfigFile) ->
+    {ok, [Config]} = file:consult(ConfigFile),
+    {blockchain, BlockchainConfig} = proplists:lookup(blockchain, Config),
+    BaseDir = proplists:get_value(base_dir, BlockchainConfig, "data"),
+    KeyConfig = case proplists:get_value(key, BlockchainConfig, undefined) of
+                    undefined -> {file, BaseDir};
+                    KC -> KC
+                end,
+    #{ pubkey := PubKey,
+       onboarding_key := OnboardingKey
+     } = keys(KeyConfig),
+    MaybeB58 = fun(undefined) -> undefined;
+                  (Key) -> libp2p_crypto:pubkey_to_b58(Key)
+               end,
+    Props = [{pubkey, MaybeB58(PubKey)},
+             {onboarding_key, MaybeB58(OnboardingKey)}
+            ] ++ [ {animal_name, element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:pubkey_to_b58(PubKey)))} || PubKey /= undefined ],
+    lists:foreach(fun(Term) -> io:format("~tp.~n", [Term]) end, Props).
+
+%%
+%% Utilities
+%%
+
+%% Helper funtion to retry automatic keyslot key generation and
+%% locking the first time we encounter an empty keyslot.
+get_public_key(ECCPid, Slot) ->
+    ecc508:wake(ECCPid),
+    case ecc508:genkey(ECCPid, public, Slot) of
+        {ok, PubKey} ->
+            case ecc_compact:is_compact(PubKey) of
+                {true, _} ->
+                    {ok, {ecc_compact, PubKey}, Slot};
+                false ->
+                    %% initial hotspots had a bug where they
+                    %% did not generate a compact key here.
+                    %% This code is fallback to use a secondary
+                    %% slot to handle this case.
+                    get_public_key(ECCPid, Slot + 1)
+            end;
+        {error, ecc_response_exec_error} ->
+            %% key is not present, generate one
+            %%
+            %% XXX this is really not the best thing to do here
+            %% but deadlines rule everything around us
+            ok = gen_compact_key(ECCPid, Slot, 100),
+            get_public_key(ECCPid, Slot)
+    end.
+
+gen_compact_key(_Pid, _Slot, 0) ->
+    {error, compact_key_create_failed};
+gen_compact_key(Pid, Slot, N) when N > 0 ->
+    case  ecc508:genkey(Pid, private, Slot) of
+        {ok, PubKey} ->
+            case ecc_compact:is_compact(PubKey) of
+                {true, _} -> ok;
+                false -> gen_compact_key(Pid, Slot, N - 1)
+            end;
+        {error, Error} ->
+            {error, Error}
+    end.


### PR DESCRIPTION
This adds a miner/bin/print_keys shell script that prints out a list of terms for onboarding/pub keys. 

To get this to work the miner_sup startup for key retrieval was moved into a new miner_keys module