### PR TITLE
Tweak the behaviour of miner_lora a bit

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -66,7 +66,7 @@ send_poc(Payload, When, Freq, DataRate, Power) ->
 init(Args) ->
     UDPIP = maps:get(radio_udp_bind_ip, Args),
     UDPPort = maps:get(radio_udp_bind_port, Args),
-    {ok, Socket} = gen_udp:open(UDPPort, [binary, {active, 100}, {ip, UDPIP}]),
+    {ok, Socket} = gen_udp:open(UDPPort, [binary, {reuseaddr, true}, {active, 100}, {ip, UDPIP}]),
     {ok, #state{socket=Socket,
                 sig_fun = maps:get(sig_fun, Args),
                 pubkey_bin = blockchain_swarm:pubkey_bin()}}.
@@ -287,7 +287,9 @@ route(Pkt) ->
                 true ->
                     {onion, longfi:payload(LongFiPkt)};
                 false ->
-                    {longfi, longfi:oui(LongFiPkt)}
+                    %% we currently don't expect non-onion packets,
+                    %% this is probably a false positive on a LoRaWAN packet
+                      route_non_longfi(Pkt)
             catch _:_ ->
                       route_non_longfi(Pkt)
             end

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -662,10 +662,11 @@ exec_dist_test(TestCase, Config, VarMap) ->
 
 setup_dist_test(TestCase, Config, VarMap) ->
     Miners = ?config(miners, Config),
-    MinerCount = length(Miners),
+    MinersAndPorts = ?config(ports, Config),
     {_, Locations} = lists:unzip(initialize_chain(Miners, TestCase, Config, VarMap)),
     GenesisBlock = get_genesis_block(Miners, Config),
-    miner_fake_radio_backplane:start_link(maps:get(?poc_version, VarMap), 45000, lists:zip(lists:seq(46001, 46000 + MinerCount), Locations)),
+    RadioPorts = [ P || {_Miner, {_TP, P}} <- MinersAndPorts ],
+    miner_fake_radio_backplane:start_link(maps:get(?poc_version, VarMap), 45000, lists:zip(RadioPorts, Locations)),
     timer:sleep(5000),
     true = load_genesis_block(GenesisBlock, Miners, Config),
     miner_fake_radio_backplane ! go,


### PR DESCRIPTION
* Use reuseaddr so we have a better chance of grabbing the port after a
  crash, or during tests
* Assume any non onion packet is a lorawan packet, we've seen some false
  positives