### PR TITLE
Fix potential instability in POC test suite 

### DIFF
--- a/src/miner_sup.erl
+++ b/src/miner_sup.erl
@@ -42,7 +42,7 @@ start_link() ->
 init(_Args) ->
     SupFlags = #{
         strategy => rest_for_one,
-        intensity => 2,
+        intensity => 10,
         period => 5
     },
 

--- a/src/miner_sup.erl
+++ b/src/miner_sup.erl
@@ -42,7 +42,7 @@ start_link() ->
 init(_Args) ->
     SupFlags = #{
         strategy => rest_for_one,
-        intensity => 10,
+        intensity => 2,
         period => 5
     },
 

--- a/src/poc/miner_onion_server.erl
+++ b/src/poc/miner_onion_server.erl
@@ -50,8 +50,7 @@
     miner_name :: binary(),
     sender :: undefined | {pid(), term()},
     packet_id = 0 :: non_neg_integer(),
-    chain :: undefined  | blockchain:blockchain(),
-    chain_retry_count = 0 :: integer()
+    chain :: undefined  | blockchain:blockchain()
 }).
 
 -define(BLOCK_RETRY_COUNT, 10).

--- a/src/poc/miner_onion_server.erl
+++ b/src/poc/miner_onion_server.erl
@@ -49,7 +49,9 @@
     ecdh_fun,
     miner_name :: binary(),
     sender :: undefined | {pid(), term()},
-    packet_id = 0 :: non_neg_integer()
+    packet_id = 0 :: non_neg_integer(),
+    chain :: undefined  | blockchain:blockchain(),
+    chain_retry_count = 0 :: integer()
 }).
 
 -define(BLOCK_RETRY_COUNT, 10).
@@ -168,20 +170,42 @@ send_witness(Data, OnionCompactKey, Time, RSSI, Retry) ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 init(Args) ->
+    lager:info("init with ~p", [Args]),
     {ok, Name} = erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(blockchain_swarm:pubkey_bin())),
     MinerName = binary:replace(erlang:list_to_binary(Name), <<"-">>, <<" ">>, [global]),
+    Chain = blockchain_worker:blockchain(),
     State = #state{
         compact_key = blockchain_swarm:pubkey_bin(),
         ecdh_fun = maps:get(ecdh_fun, Args),
-        miner_name = unicode:characters_to_binary(MinerName, utf8)
+        miner_name = unicode:characters_to_binary(MinerName, utf8),
+        chain = Chain
     },
-    lager:info("init with ~p", [Args]),
     {ok, State}.
 
 handle_call(compact_key, _From, #state{compact_key=CK}=State) when CK /= undefined ->
     {reply, {ok, CK}, State};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
+
+handle_cast(Msg, #state{chain = undefined, chain_retry_count = RetryCount} = State) when RetryCount < 100 ->
+    %% we have no chain yet, so catch all casts,
+    %% and attempt to get the chain, then put the msg back in the queue
+    %% we will do this max of 100 times and then let things crash...
+    %% if chain isnt up by then, we will want to know about...
+    lager:info("received ~p whilst no chain.  Will attempt to get chain and requeue", [Msg]),
+    NC =
+        case blockchain_worker:blockchain() of
+            undefined ->
+                %% chain still not ready, to take a breather and give it a space to come up
+                timer:sleep(250),
+                undefined;
+            Chain ->
+                Chain
+        end,
+    %% requeue the msg back to ourselves, brutal...
+    ok = gen_server:cast(?MODULE, Msg),
+    {noreply, State#state{chain = NC, chain_retry_count = RetryCount + 1}};
+
 
 handle_cast({decrypt_p2p, <<IV:2/binary,
                             OnionCompactKey:33/binary,
@@ -232,10 +256,9 @@ wait_for_block_(Fun, Count) ->
             wait_for_block_(Fun, Count - 1)
     end.
 
-decrypt(Type, IV, OnionCompactKey, Tag, CipherText, RSSI, Stream, #state{ecdh_fun=ECDHFun}=State) ->
+decrypt(Type, IV, OnionCompactKey, Tag, CipherText, RSSI, Stream, #state{ecdh_fun=ECDHFun, chain = Chain}=State) ->
     <<POCID:10/binary, _/binary>> = OnionCompactKey,
     OnionKeyHash = crypto:hash(sha256, OnionCompactKey),
-    Chain = blockchain_worker:blockchain(),
     NewState = case try_decrypt(IV, OnionCompactKey, OnionKeyHash, Tag, CipherText, ECDHFun, Chain) of
         poc_not_found ->
             Ledger = blockchain:ledger(Chain),
@@ -281,9 +304,13 @@ decrypt(Type, IV, OnionCompactKey, Tag, CipherText, RSSI, Stream, #state{ecdh_fu
 -ifdef(EQC).
 -spec try_decrypt(binary(), binary(), binary(), binary(), function()) -> {ok, binary(), binary()} | {error, any()}.
 try_decrypt(IV, OnionCompactKey, Tag, CipherText, ECDHFun) ->
-    Chain = blockchain_worker:blockchain(),
-    OnionKeyHash = crypto:hash(sha256, OnionCompactKey),
-    try_decrypt(IV, OnionCompactKey, OnionKeyHash, Tag, CipherText, ECDHFun, Chain).
+    case blockchain_worker:blockchain() of
+        undefined->
+            {error, chain_not_ready};
+        Chain ->
+            OnionKeyHash = crypto:hash(sha256, OnionCompactKey),
+            try_decrypt(IV, OnionCompactKey, OnionKeyHash, Tag, CipherText, ECDHFun, Chain)
+    end.
 -endif.
 
 -spec try_decrypt(binary(), binary(), binary(), binary(), binary(), function(), blockchain:blockchain()) -> poc_not_found | {ok, binary(), binary()} | {error, any()}.


### PR DESCRIPTION
the POC suite has a tendency to fail randomly.  I traced this back to the onion server crashing out a number of times in quick succession and breaching the miner_sup restart intensity leading to the entire miner tree restarting.

Each poc suite test initialises with the the following:

{_, Locations} = lists:unzip(initialize_chain(Miners, TestCase, Config, VarMap)),
GenesisBlock = get_genesis_block(Miners, Config),
miner_fake_radio_backplane:start_link(maps:get(?poc_version, VarMap), 45000, lists:zip(lists:seq(46001, 46000 + MinerCount), Locations)),
timer:sleep(5000),
true = load_genesis_block(GenesisBlock, Miners, Config),

As part of `initialize_chain` there is a call to the consensus mgr to do the initial_dkg.   For those nodes part of the CG group this takes sufficient time to complete to allow the chain to be fully setup before we advance to the main part of the tests.

However for the node not part of the CG group and thus not part of the DKG, the call to consensus mgr returns much quicker and we move onto the main part of the tests sooner.  At this point the onion server may receive decrypt requests which will then result in calls to blockchain_worker to get the chain, followed by a call to the ledger.   At times the blockchain worker will not be fully setup with the chain and it will return undefined.  At this point and the onion server will crash out on `Ledger = blockchain:ledger(Chain)` calls

The miner sup will then immediately restart the onion server and the same crash will re-occur.  As the miner sup restart strategy only allows 2 restarts in 5 seconds we then see the entire miner tree being restarted and the tests will fail.

To address the above, this fix simply captures and drops all decrypt requests whilst the there is no chain and re attempts to get the chain from blockchain worker.

