### PR TITLE
Bump assumed valid block to 249675

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,9 +22,9 @@
   [
    {honor_assumed_valid, true},
 
-   {assumed_valid_block_height, 234600},
+   {assumed_valid_block_height, 249675},
    {assumed_valid_block_hash,
-    <<45,102,251,226,4,4,160,150,134,197,191,253,135,82,99,240,208,233,127,129,121,86,79,157,170,26,74,246,200,101,195,134>>},
+    <<244,213,32,200,79,169,196,15,172,236,87,100,234,37,75,250,184,39,108,110,175,130,200,54,117,56,116,127,222,94,120,103>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
Eshell V10.5  (abort with ^G)
(miner@127.0.0.1)1> {ok, Block} = blockchain:get_block(249675, blockchain_worker:blockchain()).
{ok,{blockchain_block_v1_pb,
        <<32,211,76,111,62,245,167,155,205,142,128,125,134,119,84,
          1,237,146,109,43,216,39,8,16,122,...>>,
        249675,1584372738,249697,
...
(miner@127.0.0.1)2> rp(blockchain_block:hash_block(Block)).
<<244,213,32,200,79,169,196,15,172,236,87,100,234,37,75,
  250,184,39,108,110,175,130,200,54,117,56,116,127,222,94,
  120,103>>
ok
(miner@127.0.0.1)3> rp(blockchain_block:height(Block)).
249675
ok
```