### PR TITLE
increase catchup, and also slowdown

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -582,20 +582,20 @@ set_next_block_timer(State=#state{blockchain=Chain, start_block_time=StartBlockT
                        undefined ->
                            BlockTime;
                        _ ->
-                           Diff = ceil((LastBlockTimestamp - StartBlockTime) /
-                                           (Height - StartHeight)),
-                           case Diff of
-                               N when N > 0 ->
-                                   min(ceil(N * N), 15);
-                               N ->
-                                   %% to maintain sensitivity, and actually cap slowdown,
-                                   %% invert all the operations here, and use abs to
-                                   %% preserve sign.
-                                   max(floor(N * abs(N)), -15)
-                           end
+                           (LastBlockTimestamp - StartBlockTime) / (Height - StartHeight)
                    end,
-    BlockTimeDeviation = BlockTime - AvgBlockTime,
+    BlockTimeDeviation0 = BlockTime - AvgBlockTime,
     lager:info("average ~p block times ~p difference ~p", [Height, AvgBlockTime, BlockTime - AvgBlockTime]),
+    BlockTimeDeviation =
+        case BlockTimeDeviation0 of
+            N when N > 0 ->
+                min(ceil(N * N), 15);
+            N ->
+                %% to maintain sensitivity, and actually cap slowdown,
+                %% invert all the operations here, and use abs to
+                %% preserve sign.
+                max(floor(N * abs(N)), -15)
+        end,
     NextBlockTime = max(0, (LastBlockTimestamp + BlockTime + BlockTimeDeviation) - Now),
     lager:info("Next block after ~p is in ~p seconds", [LastBlockTimestamp, NextBlockTime]),
     Timer = erlang:send_after(NextBlockTime * 1000, self(), block_timeout),


### PR DESCRIPTION
The existing catchup function isn't really aggressive enough for the current network quality.   This change does two things:

1) We square the difference (and cap it to 15s), so that we push more aggressively to 0 when we drift.
2) we invert the logic for slowdown, so that we're tight around 0, rather than drifting up to 1s fast before we start to correct.