### PR TITLE
Bump assumed valid block to 263260

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,9 +22,9 @@
   [
    {honor_assumed_valid, true},
 
-   {assumed_valid_block_height, 249675},
+   {assumed_valid_block_height, 263260},
    {assumed_valid_block_hash,
-    <<244,213,32,200,79,169,196,15,172,236,87,100,234,37,75,250,184,39,108,110,175,130,200,54,117,56,116,127,222,94,120,103>>},
+    <<1,70,42,104,128,154,186,190,212,63,116,233,134,57,145,177,109,89,25,120,157,32,84,156,247,189,255,113,204,143,78,80>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
{ok, Block} = blockchain:get_block(263260, blockchain_worker:blockchain()).
...
(miner@127.0.0.1)2> rp(blockchain_block:hash_block(Block)).
<<1,70,42,104,128,154,186,190,212,63,116,233,134,57,145,
  177,109,89,25,120,157,32,84,156,247,189,255,113,204,143,
  78,80>>
ok
(miner@127.0.0.1)3> blockchain_block:height(Block).
263260
```