### PR TITLE
Use an explicit prefilter when a hbbft transaction set has been agreed

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -247,10 +247,11 @@ relcast_queue(Group) ->
                    Txns :: blockchain_txn:txns(),
                    HBBFTRound :: non_neg_integer())
                   -> {ok,
-                      libp2p_crypto:pubkey_bin(),
-                      binary(),
-                      binary(),
-                      blockchain_txn:txns()} |
+                      Address :: libp2p_crypto:pubkey_bin(),
+                      UsignedBinaryBlock :: binary(),
+                      Signature :: binary(),
+                      PendingTxns :: blockchain_txn:txns(),
+                      InvalidTxns :: blockchain_txn:txns()} |
                      {error, term()}.
 create_block(Metadata, Txns, HBBFTRound) ->
     try
@@ -461,7 +462,7 @@ handle_call({create_block, Metadata, Txns, HBBFTRound}, _From, State) ->
                            [self(), NewBlock, TxnsToInsert]),
                 %% return both valid and invalid transactions to be deleted from the buffer
                 {ok, libp2p_crypto:pubkey_to_bin(MyPubKey), BinNewBlock,
-                 Signature, TxnsToInsert ++ InvalidTransactions};
+                 Signature, TxnsToInsert, InvalidTransactions};
             [_OtherBlockHash] ->
                 {error, stale_hash};
             List ->

--- a/src/miner_hbbft_sidecar.erl
+++ b/src/miner_hbbft_sidecar.erl
@@ -9,7 +9,8 @@
          start_link/0,
          submit/1,
          set_group/1,
-         new_round/2
+         new_round/2,
+         prefilter_round/2
         ]).
 
 %% gen_server callbacks
@@ -53,8 +54,13 @@ set_group(Group) ->
     lager:debug("setting group to ~p", [Group]),
     gen_server:call(?SERVER, {set_group, Group}, infinity).
 
-new_round(Buf, Txns) ->
-    gen_server:call(?SERVER, {new_round, Buf, Txns}, infinity).
+-spec new_round([binary()], [binary()]) -> [binary()].
+new_round(Buf, BinTxns) ->
+    gen_server:call(?SERVER, {new_round, Buf, BinTxns}, infinity).
+
+-spec prefilter_round([binary()], blockchain_txn:txns()) -> [binary()].
+prefilter_round(Buf, Txns) ->
+    gen_server:call(?SERVER, {prefilter_round, Buf, Txns}, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -141,6 +147,17 @@ handle_call({new_round, Buf, RemoveTxns}, _From, #state{chain = Chain} = State) 
     Buf1 = Buf -- RemoveTxns,
     Buf2 = filter_txn_buffer(Buf1, Chain),
     {reply, Buf2, State};
+handle_call({prefilter_round, _Buf, _RemoveTxns}, _From, #state{chain = undefined} = State) ->
+    {reply, [], State};
+handle_call({prefilter_round, Buf, PendingTxns}, _From, #state{chain = Chain} = State) ->
+    Ledger = blockchain:ledger(Chain),
+    blockchain_ledger_v1:reset_context(Ledger),
+    %% pre-seed the ledger with the pending txns from the next block
+    [ ok = blockchain_txn:absorb(P, Chain) || P <- PendingTxns ],
+    %% filter the buffer in light of the pending next block
+    Buf2 = filter_txn_buffer(Buf, Chain),
+    {reply, Buf2, State};
+
 handle_call(_Request, _From, State) ->
     lager:warning("unexpected call ~p from ~p", [_Request, _From]),
     Reply = ok,


### PR DESCRIPTION
Prior to this change, we had 2 calls to a sidecar transaction filter
operation, one of them was done as soon as the block's contents were
agreed on and one was done at the start of a new round, if the prior
filtering had not been done.

The prefilter had a problem that it didn't tell the sidecar what
transactions were pending. This led to the sidecar rejecting all
transactions that depended on the transactions about to appear in the
next block.

This change adds an explicit prefilter that absorbs the valid
transactions from the pending block and then re-evaluates all the
buffered transactions against that. This means that transactions that
depend on the tranactions in the pending block will no longer be
filtered out.

Additionally, this change seperates pending transactions in the next
block from invalid transactions in the return from miner:create_block so
we don't bother trying to absorb invalid transactions in the prefilter.