### PR TITLE
bump to blockchain core version with txn mgr cache as records

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},3},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"307658b82ca3670c489e8c7096739fe6832a27ae"}},
+       {ref,"b857668ca7d5c63e693c49269b6f35d893ce9efe"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},3},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"97c061210643f7fefe0bbbf3a21b7d348a1069cd"}},
+       {ref,"307658b82ca3670c489e8c7096739fe6832a27ae"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",

--- a/test/miner_payment_txn_SUITE.erl
+++ b/test/miner_payment_txn_SUITE.erl
@@ -300,7 +300,7 @@ dependent_payment_test(Config) ->
                                                                end
                                                        end, Miners),
                                              [true] == lists:usort(HaveNoncesIncremented)
-                                     end, 60, 5000),
+                                     end, 100, 5000),
     case Result of
         true ->
             ok;

--- a/test/miner_payment_txn_SUITE.erl
+++ b/test/miner_payment_txn_SUITE.erl
@@ -295,7 +295,7 @@ dependent_payment_test(Config) ->
                                                                        TxnList = ct_rpc:call(Miner, blockchain_txn_mgr, txn_list, []),
                                                                        C = ct_rpc:call(Miner, blockchain_worker, blockchain, []),
                                                                        H = ct_rpc:call(Miner, blockchain, height, [C]),
-                                                                       ct:pal("nonce for ~p is ~p, ~p transactions in queue at height ~p", [Miner, Nonce, length(TxnList), H]),
+                                                                       ct:pal("nonce for ~p is ~p, ~p transactions in queue at height ~p", [Miner, Nonce, maps:size(TxnList), H]),
                                                                        false
                                                                end
                                                        end, Miners),

--- a/test/miner_txn_mgr_SUITE.erl
+++ b/test/miner_txn_mgr_SUITE.erl
@@ -350,4 +350,4 @@ nonce_updated_for_miner(Addr, ExpectedNonce, ConMiners)->
                             Nonce == ExpectedNonce
                           end, ConMiners),
             [true] == lists:usort(HaveNoncesIncremented)
-        end, 100, 1000).
+        end, 200, 1000).


### PR DESCRIPTION
Update test to account for txn mgr's txn_list returning a map of txns ( key: txn, value: TxnData )

tweak some test timers for better stability

Associated blockchain core pr: 

https://github.com/helium/blockchain-core/pull/431