### PR TITLE
Ignore - test tweaks WIP

### DIFF
--- a/test/miner_blockchain_SUITE.erl
+++ b/test/miner_blockchain_SUITE.erl
@@ -223,7 +223,8 @@ election_test(Config) ->
 
     %% we've seen all of the nodes, yay.  now make sure that more than
     %% one election can happen.
-    ok = miner_ct_utils:wait_for_gte(epoch, Miners, 3, any, 90),
+    %% we wait until we have seen all miners hit an epoch of 3
+    ok = miner_ct_utils:wait_for_gte(epoch, Miners, 3, all, 90),
 
     %% stop the first 4 miners
     TargetMiners = lists:sublist(Miners, 1, 4),
@@ -233,7 +234,7 @@ election_test(Config) ->
     ok = miner_ct_utils:wait_for_app_stop(TargetMiners, miner),
 
     %% delete the groups
-    ok = miner_ct_utils:delete_dirs(BaseDir ++ "_*{1,2,3,4}*", "/blockchain_swarm/groups/*"),
+    ok = miner_ct_utils:delete_dirs(BaseDir ++ "_{1,2,3,4}*", "/blockchain_swarm/groups/*"),
 
     %% start the stopped miners back up again
     miner_ct_utils:start_miners(TargetMiners),
@@ -242,8 +243,8 @@ election_test(Config) ->
     HChain = ct_rpc:call(hd(Miners), blockchain_worker, blockchain, []),
     {ok, Height} = ct_rpc:call(hd(Miners), blockchain, height, [HChain]),
 
-    %% wait until height has increased by 5
-    ok = miner_ct_utils:wait_for_gte(height, Miners, 5),
+    %% height might go up by one, but it should not go up by 5
+    {_, false} = miner_ct_utils:wait_for_gte(height, Miners, Height + 5),
 
     %% third: mint and submit the rescue txn, shrinking the group at
     %% the same time.
@@ -253,7 +254,9 @@ election_test(Config) ->
 
     HChain2 = ct_rpc:call(hd(Miners), blockchain_worker, blockchain, []),
     {ok, HeadBlock} = ct_rpc:call(hd(Miners), blockchain, head_block, [HChain2]),
+
     NewHeight = blockchain_block:height(HeadBlock) + 1,
+    ct:pal("new height is ~p", [NewHeight]),
     Hash = blockchain_block:hash_block(HeadBlock),
 
     Vars = #{num_consensus_members => 4},
@@ -265,10 +268,9 @@ election_test(Config) ->
     VarsTxn = blockchain_txn_vars_v1:proof(Txn, Proof),
 
     {ElectionEpoch, _EpochStart} = blockchain_block_v1:election_info(HeadBlock),
+    ct:pal("current election epoch: ~p", [ElectionEpoch]),
 
     GrpTxn = blockchain_txn_consensus_group_v1:new(NewGroup, <<>>, Height, 0),
-
-    ct:pal("new height is ~p", [NewHeight]),
 
     RescueBlock = blockchain_block_v1:rescue(
                     #{prev_hash => Hash,
@@ -297,10 +299,10 @@ election_test(Config) ->
     ct:pal("FirstNode Swarm: ~p", [Swarm]),
     N = length(Miners),
     ct:pal("N: ~p", [N]),
-     _ = ct_rpc:call(FirstNode, blockchain_gossip_handler, add_block, [Swarm, SignedBlock, Chain, self()]),
+    ok = ct_rpc:call(FirstNode, blockchain_gossip_handler, add_block, [SignedBlock, Chain, self()]),
 
-    %% wait until height has increased by 5
-    ok = miner_ct_utils:wait_for_gte(height, Miners, 5),
+    %% wait until height has increased by 3
+    ok = miner_ct_utils:wait_for_gte(height, Miners, NewHeight),
 
     %% check consensus and non consensus miners
     {NewConsensusMiners, NewNonConsensusMiners} = miner_ct_utils:miners_by_consensus_state(Miners),
@@ -310,15 +312,13 @@ election_test(Config) ->
     ct:pal("stop list ~p", [StopList]),
     miner_ct_utils:stop_miners(StopList),
 
-
-    %% sleel a lil then start the nodes back up again
+    %% sleep a lil then start the nodes back up again
     timer:sleep(5000),
 
     miner_ct_utils:start_miners(StopList),
 
     %% fourth: confirm that blocks and elections are proceeding
     ok = miner_ct_utils:wait_for_gte(epoch, Miners, ElectionEpoch + 1),
-
     ok.
 
 

--- a/test/miner_ct_macros.hrl
+++ b/test/miner_ct_macros.hrl
@@ -4,7 +4,7 @@
 -define(assertAsync(Expr, BoolExpr, ExprRetry, ExprDelay),
     Res = miner_ct_utils:wait_until(fun() -> (Expr),(BoolExpr) end, ExprRetry, ExprDelay),
     case Res of
-        false -> 
+        false ->
             erlang:error({assert,
                     [{module, ?MODULE},
                       {line, ?LINE},
@@ -13,7 +13,17 @@
                       {value ,Res}
                     ]
             });
-        _ -> 
+        _ ->
             Res
     end).
 
+%% version of the above but without a final bool expression and no error assert upon failure
+%% the caller determines success criteria, doesnt require the wait_until to return true
+-define(noAssertAsync(Expr, ExprRetry, ExprDelay),
+    Res = miner_ct_utils:wait_until(fun() -> (Expr) end, ExprRetry, ExprDelay),
+    case Res of
+        false ->
+            false;
+        _ ->
+            Res
+    end).

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -70,8 +70,9 @@ stop_miners(Miners) ->
 
 stop_miners(Miners, Retries) ->
     [begin
-          ct_rpc:call(Miner, application, stop, [miner], 300),
-          ct_rpc:call(Miner, application, stop, [blockchain], 300)
+         ct_rpc:call(Miner, application, stop, [blockchain], 300),
+         ct_rpc:call(Miner, application, stop, [miner], 300)
+
      end
      || Miner <- Miners],
     ok = miner_ct_utils:wait_for_app_stop(Miners, miner, Retries),
@@ -205,8 +206,8 @@ wait_for_gte(height_exactly = Type, Miners, Threshold)->
     wait_for_gte(Type, Miners, Threshold, all, 60).
 
 wait_for_gte(Type, Miners, Threshold, Mod, Retries)->
-    Res = ?assertAsync(begin
-                     Result = lists:Mod(
+    Res = ?noAssertAsync(begin
+                     lists:Mod(
                         fun(Miner) ->
                              try
                                  handle_gte_type(Type, Miner, Threshold)
@@ -214,13 +215,13 @@ wait_for_gte(Type, Miners, Threshold, Mod, Retries)->
                                      false
                              end
                         end, miner_ct_utils:shuffle(Miners))
-                 end,
-        Result == true, Retries, timer:seconds(1)),
-
+                    end,
+        Retries, timer:seconds(1)),
     case Res of
         true -> ok;
         false -> {error, false}
     end.
+
 
 wait_for_registration(Miners, Mod) ->
     wait_for_registration(Miners, Mod, 300).
@@ -317,7 +318,7 @@ wait_for_chain_var_update(Miners, Key, Value, Timeout)->
 delete_dirs(DirWildcard, SubDir)->
     Dirs = filelib:wildcard(DirWildcard),
     [begin
-         ct:pal("rm dir ~s", [Dir]),
+         ct:pal("rm dir ~s", [Dir ++ SubDir]),
          os:cmd("rm -r " ++ Dir ++ SubDir)
      end
      || Dir <- Dirs],


### PR DESCRIPTION
This fixes the miner's blockchain_SUITE tests.  Two primary problems are addressed:

1.  The test includes a call to blockchain_gossip_handler:add_block.  This arity here was incorrect since https://github.com/helium/blockchain-core/commit/40515021e26de76534e148846c72d429e9f06080#diff-70ab3c21b9b17903889bfc6a4d66fac4

2.  Instability was introduced to the test with an incorrect use of miner_ct_util:wait_for_gte since the miner tests were refactored by me back in November.  I compared the current against the test prior to this work and made a number of corrections.
