### PR TITLE
Fix blockchain_SUITE's election test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - commands:
       - ". $HOME/.asdf/asdf.sh"
-      - "asdf local erlang 21.3"
+      - "asdf local erlang 22.1.8"
       - "make compile"
       - "make ci"
     name: ":hammer: build"

--- a/test/miner_ct_macros.hrl
+++ b/test/miner_ct_macros.hrl
@@ -4,7 +4,7 @@
 -define(assertAsync(Expr, BoolExpr, ExprRetry, ExprDelay),
     Res = miner_ct_utils:wait_until(fun() -> (Expr),(BoolExpr) end, ExprRetry, ExprDelay),
     case Res of
-        false -> 
+        false ->
             erlang:error({assert,
                     [{module, ?MODULE},
                       {line, ?LINE},
@@ -13,7 +13,17 @@
                       {value ,Res}
                     ]
             });
-        _ -> 
+        _ ->
             Res
     end).
 
+%% version of the above but without a final bool expression and no error assert upon failure
+%% the caller determines success criteria, doesnt require the wait_until to return true
+-define(noAssertAsync(Expr, ExprRetry, ExprDelay),
+    Res = miner_ct_utils:wait_until(fun() -> (Expr) end, ExprRetry, ExprDelay),
+    case Res of
+        false ->
+            false;
+        _ ->
+            Res
+    end).

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -67,8 +67,9 @@ stop_miners(Miners) ->
 
 stop_miners(Miners, Retries) ->
     [begin
-          ct_rpc:call(Miner, application, stop, [miner], 300),
-          ct_rpc:call(Miner, application, stop, [blockchain], 300)
+         ct_rpc:call(Miner, application, stop, [blockchain], 300),
+         ct_rpc:call(Miner, application, stop, [miner], 300)
+
      end
      || Miner <- Miners],
     ok = miner_ct_utils:wait_for_app_stop(Miners, miner, Retries),
@@ -202,8 +203,8 @@ wait_for_gte(height_exactly = Type, Miners, Threshold)->
     wait_for_gte(Type, Miners, Threshold, all, 60).
 
 wait_for_gte(Type, Miners, Threshold, Mod, Retries)->
-    Res = ?assertAsync(begin
-                     Result = lists:Mod(
+    Res = ?noAssertAsync(begin
+                     lists:Mod(
                         fun(Miner) ->
                              try
                                  handle_gte_type(Type, Miner, Threshold)
@@ -211,13 +212,13 @@ wait_for_gte(Type, Miners, Threshold, Mod, Retries)->
                                      false
                              end
                         end, miner_ct_utils:shuffle(Miners))
-                 end,
-        Result == true, Retries, timer:seconds(1)),
-
+                    end,
+        Retries, timer:seconds(1)),
     case Res of
         true -> ok;
         false -> {error, false}
     end.
+
 
 wait_for_registration(Miners, Mod) ->
     wait_for_registration(Miners, Mod, 300).
@@ -314,7 +315,7 @@ wait_for_chain_var_update(Miners, Key, Value, Timeout)->
 delete_dirs(DirWildcard, SubDir)->
     Dirs = filelib:wildcard(DirWildcard),
     [begin
-         ct:pal("rm dir ~s", [Dir]),
+         ct:pal("rm dir ~s", [Dir ++ SubDir]),
          os:cmd("rm -r " ++ Dir ++ SubDir)
      end
      || Dir <- Dirs],


### PR DESCRIPTION
This fixes the miner's blockchain_SUITE election test. Two primary problems are addressed:

1. The test includes a call to blockchain_gossip_handler:add_block. This arity here was incorrect since helium/blockchain-core@4051502#diff-70ab3c21b9b17903889bfc6a4d66fac4

2. Instability was introduced to the test with an incorrect use of miner_ct_util:wait_for_gte since the miner tests were refactored by me back in November. I compared the current against the test prior to this work and made a number of corrections.