### PR TITLE
Log to /var/log/miner not /var/data/log/miner

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -8,7 +8,7 @@
  {lager,
   [
    {suppress_supervisor_start_stop, true},
-   {log_root, "/var/data/log/miner"},
+   {log_root, "/var/log/miner"},
    {crash_log, "crash.log"},
    {colored, true},
    {metadata_whitelist, [poc_id]},


### PR DESCRIPTION
The `/var/log` directory is mounted as tmpfs so it does not wear down the microSD.