### PR TITLE
Don't challenge without GPS lock close to assert

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,7 +35,7 @@
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},
    {peerbook_allow_rfc1918, false},
-   {metadata_fun, fun miner_utils:metadata_fun/0},
+   {metadata_fun, fun miner_util:metadata_fun/0},
    {relay_limit, 50}
   ]},
  {relcast,

--- a/config/sys.config
+++ b/config/sys.config
@@ -35,6 +35,7 @@
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},
    {peerbook_allow_rfc1918, false},
+   {metadata_fun, fun miner_utils:metadata_fun/0},
    {relay_limit, 50}
   ]},
  {relcast,

--- a/src/miner_collect.erl
+++ b/src/miner_collect.erl
@@ -1,0 +1,118 @@
+-module(miner_collect).
+
+-behaviour(gen_server).
+
+%% API
+-export([
+         start_link/0,
+         stop/0
+        ]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include_lib("blockchain/include/blockchain_vars.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state,
+        {
+         heights :: #{}
+        }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:call(?SERVER, stop).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    %% timeout for async startup
+    {ok, Height} = blockchain:height(blockchain_worker:blockchain()),
+    ok = blockchain_event:add_handler(self()),
+    {ok, #state{heights = update_heights(#{}, Height)}}.
+
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State};
+handle_call(_Request, _From, State) ->
+    lager:warning("unexpected call ~p from ~p", [_Request, _From]),
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    lager:warning("unexpected cast ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info({blockchain_event, {add_block, _, _, Ledger}},
+            #state{heights = Heights} = State) ->
+    Curr = blockchain_ledger_v1:current_height(Ledger),
+    {noreply, State#state{heights = update_heights(Heights, Curr)}};
+handle_info(_Info, State) ->
+    lager:warning("unexpected message ~p", [_Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+update_heights(Init, Curr) ->
+    %% filter for active gateways, make sure that everything is just
+    %% reporting once
+
+    Book = libp2p_swarm:peerbook(blockchain_swarm:swarm()),
+    Peers = [{Address, libp2p_peerbook:get(Book, Address)}
+             || Address <- libp2p_peerbook:keys(Book)],
+    Triples = [{Address,
+                begin
+                    Ht = libp2p_peer:signed_metadata_get(Peer, <<"height">>, 0),
+                    Ht - (Ht rem 40)
+                end,
+                libp2p_peer:signed_metadata_get(Peer, <<"ledger_fingerprint">>, undefined)}
+               || {Address, {ok, Peer}} <- Peers],
+    Filtered =
+        [{element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(X))), H, Y}
+         || {X, H, Y} <- Triples, Y /= undefined],
+    New =
+        lists:foldl(
+          fun({_Name, Height, _Fingerprint}, Acc) when Height < Curr - 200 ->
+                  maps:remove(Height, Acc);
+             ({Name, Height, Fingerprint}, Acc) ->
+                  HeightMap = maps:get(Height, Acc, #{}),
+                  FPs = maps:get(Fingerprint, HeightMap, []),
+                  Acc#{Height => HeightMap#{Fingerprint => lists:usort([Name | FPs])}}
+          end,
+          Init,
+          Filtered),
+    %% summarize
+    Summary =
+        maps:fold(
+          fun(Height, FPs, Acc) ->
+                  L = maps:to_list(FPs),
+                  L1 = [{FP, length(FPL)} || {FP, FPL} <- L],
+                  [{Height, L1} | Acc]
+          end,
+          [],
+          New),
+    S = lists:sublist(lists:reverse(lists:sort(Summary)), 4),
+    [begin
+         Rep = lists:sum([R || {_, R} <- FPCounts]),
+         FPCounts1 = [{FP, trunc((Ct/Rep) * 100), Ct}|| {FP, Ct} <- FPCounts],
+         lager:info("height ~p reporting ~p fps ~p", [Ht, Rep, lists:keysort(3, FPCounts1)])
+     end
+     || {Ht, FPCounts} <- S],
+    New.

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -94,17 +94,17 @@ position() ->
 location_ok() ->
     %% the below code is tested and working.  we're going to roll
     %% out the metadata update so app users can see their status
-    case position() of
-        {error, _Error} ->
-            lager:debug("pos err ~p", [_Error]),
-            false;
-        {ok, _} ->
-            true;
-        %% fix but too far from assert
-        {ok, _, _} ->
-            false
-    end.
-    %% true.
+    %% case position() of
+    %%     {error, _Error} ->
+    %%         lager:debug("pos err ~p", [_Error]),
+    %%         false;
+    %%     {ok, _} ->
+    %%         true;
+    %%     %% fix but too far from assert
+    %%     {ok, _, _} ->
+    %%         false
+    %% end.
+    true.
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -82,7 +82,9 @@ send_poc(Payload, When, Freq, DataRate, Power) ->
 port() ->
     gen_server:call(?MODULE, port, 11000).
 
--spec position() -> {ok, {float(), float()}} | {error, any()}.
+-spec position() -> {ok, {float(), float()}} |
+                    {ok, bad_assert, {float(), float()}} |
+                    {error, any()}.
 position() ->
     try
         gen_server:call(?MODULE, position, infinity)
@@ -104,7 +106,9 @@ location_ok() ->
     %%     {ok, _, _} ->
     %%         false
     %% end.
-    true.
+
+    %% this terrible thing is to fake out dialyzer
+    application:get_env(miner, loc_ok_default, true).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -84,7 +84,11 @@ port() ->
 
 -spec position() -> {ok, {float(), float()}} | {error, any()}.
 position() ->
-    gen_server:call(?MODULE, position, infinity).
+    try
+        gen_server:call(?MODULE, position, infinity)
+    catch _:_ ->
+            {error, no_fix}
+    end.
 
 -spec location_ok() -> true | false.
 location_ok() ->

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -8,7 +8,8 @@
     send/1,
     send_poc/5,
     port/0,
-    position/0
+    position/0,
+    location_ok/0
 ]).
 
 -export([
@@ -84,6 +85,22 @@ port() ->
 -spec position() -> {ok, {float(), float()}} | {error, any()}.
 position() ->
     gen_server:call(?MODULE, position, infinity).
+
+-spec location_ok() -> true | false.
+location_ok() ->
+    %% the below code is tested and working.  we're going to roll
+    %% out the metadata update so app users can see their status
+    case position() of
+        {error, _Error} ->
+            lager:debug("pos err ~p", [_Error]),
+            false;
+        {ok, _} ->
+            true;
+        %% fix but too far from assert
+        {ok, _, _} ->
+            false
+    end.
+    %% true.
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions

--- a/src/miner_query.erl
+++ b/src/miner_query.erl
@@ -1,0 +1,26 @@
+-module(miner_query).
+
+-compile(export_all).
+
+
+poc_analyze(_Start, _End) ->
+    ok.
+
+
+txns(Type, Start, End) when is_atom(Type) ->
+    txns([Type], Start, End);
+txns(Types, Start, End) ->
+    Txns = txns(Start, End),
+    lists:filter(fun(T) -> lists:member(blockchain_txn:type(T), Types) end, Txns).
+
+txns(Start, End) ->
+    Blocks = blocks(Start, End),
+    lists:flatten(lists:map(fun blockchain_block:transactions/1, Blocks)).
+
+blocks(Start, End) ->
+    Chain = blockchain_worker:blockchain(),
+    [begin
+         {ok, B} = blockchain:get_block(N, Chain),
+         B
+     end
+     || N <- lists:seq(Start, End)].

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -9,7 +9,8 @@
          index_of/2,
          h3_index/3,
          median/1,
-         mark/2
+         mark/2,
+         metadata_fun/0
         ]).
 
 %%--------------------------------------------------------------------
@@ -61,4 +62,29 @@ mark(Module, Mark) ->
                                [Module, Prev, Mark, End - Start])
             end;
         _ -> ok
+    end.
+
+metadata_fun() ->
+    try
+        Map = blockchain_worker:signed_metadata_fun(),
+        case miner_lora:position() of
+            %% GPS location that's adequately close to the asserted
+            %% location
+            {ok, _} ->
+                Map#{<<"gps_fix_quality">> => <<"good_fix">>};
+            %% the assert location is too far from the fix
+            {ok, bad_assert, _} ->
+                Map#{<<"gps_fix_quality">> => <<"bad_assert">>};
+            %% no gps fix
+            {error, no_fix} ->
+                Map#{<<"gps_fix_quality">> => <<"no_fix">>};
+            %% no location asserted somehow
+            {error, not_asserted} ->
+                Map#{<<"gps_fix_quality">> => <<"not_asserted">>};
+            %% got nonsense or a hopefully transient error, return nothing
+            _ ->
+                Map
+        end
+    catch _:_ ->
+            #{}
     end.

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -85,7 +85,6 @@ metadata_fun() ->
             _ ->
                 Map#{<<"gps_fix_quality">> => <<"no_fix">>}
         end
-    catch C:E:S ->
-            lager:info("fuuu ~p ~p ~p", [C, E, S]),
+    catch _:_ ->
             #{}
     end.

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -83,8 +83,9 @@ metadata_fun() ->
                 Map#{<<"gps_fix_quality">> => <<"not_asserted">>};
             %% got nonsense or a hopefully transient error, return nothing
             _ ->
-                Map
+                Map#{<<"gps_fix_quality">> => <<"no_fix">>}
         end
-    catch _:_ ->
+    catch C:E:S ->
+            lager:info("fuuu ~p ~p ~p", [C, E, S]),
             #{}
     end.

--- a/src/poc/miner_poc_statem.erl
+++ b/src/poc/miner_poc_statem.erl
@@ -639,16 +639,19 @@ allow_request(BlockHash, #data{blockchain=Blockchain,
                     end
             end,
         LocationOK = true,
-            case miner_lora:position() of
-                {error, _Error} ->
-                    lager:debug("pos err ~p", [_Error]),
-                    false;
-                {ok, _} ->
-                    true;
-                %% fix but too far from assert
-                {ok, _, _} ->
-                    false
-            end,
+        %% the below code is tested and working.  we're going to roll
+        %% out the metadata update so app users can see their status
+        %% before it is enforced.
+            %% case miner_lora:position() of
+            %%     {error, _Error} ->
+            %%         lager:debug("pos err ~p", [_Error]),
+            %%         false;
+            %%     {ok, _} ->
+            %%         true;
+            %%     %% fix but too far from assert
+            %%     {ok, _, _} ->
+            %%         false
+            %% end,
         ChallengeOK andalso LocationOK
     catch Class:Err:Stack ->
             lager:warning("error determining if request allowed: ~p:~p ~p",

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -68,7 +68,7 @@ all() ->
      poc_dist_v8_partitioned_test,
      poc_dist_v8_partitioned_lying_test,
      %% uncomment when poc placement enforcement starts.
-     no_status_v8_test,
+     %% no_status_v8_test,
      restart_test].
 
 init_per_testcase(basic_test = TestCase, Config) ->

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -68,7 +68,7 @@ all() ->
      poc_dist_v8_partitioned_test,
      poc_dist_v8_partitioned_lying_test,
      %% uncomment when poc placement enforcement starts.
-     %% no_status_v8_test,
+     no_status_v8_test,
      restart_test].
 
 init_per_testcase(basic_test = TestCase, Config) ->

--- a/test/miner_poc_SUITE.erl
+++ b/test/miner_poc_SUITE.erl
@@ -67,7 +67,8 @@ all() ->
      poc_dist_v8_test,
      poc_dist_v8_partitioned_test,
      poc_dist_v8_partitioned_lying_test,
-     no_status_v8_test,
+     %% uncomment when poc placement enforcement starts.
+     %% no_status_v8_test,
      restart_test].
 
 init_per_testcase(basic_test = TestCase, Config) ->


### PR DESCRIPTION
This is a WIP version to get some feedback on the approach here.

The idea is that we skim GPS info off of our status packet and store it in the `miner_lora` server.  Then we check if it's close enough to our asserted position to see if we're allowed to make any requests.

Main questions here: 
1. Is 75 meters too lenient? Too strict?
2. Some other GPS using PRs we do some additional position adjustment, do we need to do those here?