### PR TITLE
Docker tweaks

### DIFF
--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -28,12 +28,14 @@ FROM erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc
 RUN ulimit -n 64000
-
-WORKDIR /opt/miner
+RUN echo -e '#!/bin/bash\necho hello' > /usr/bin/hi && \
+    chmod +x /usr/bin/hi
 
 ENV COOKIE=miner \
     # Write files generated during startup to /tmp
-    RELX_OUT_FILE_PATH=/tmp
+    RELX_OUT_FILE_PATH=/tmp \
+    # make miner interactions easier
+    PATH=$PATH:/opt/miner/bin
 
 COPY --from=builder /opt/rel /opt/miner
 

--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -37,4 +37,7 @@ ENV COOKIE=miner \
 
 COPY --from=builder /opt/rel /opt/miner
 
+ENTRYPOINT ["/opt/miner/bin/miner"]
+CMD ["foreground"]
+
 #CMD tail -f /dev/null

--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -28,8 +28,8 @@ FROM erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc
 RUN ulimit -n 64000
-RUN echo -e '#!/bin/bash\necho hello' > /usr/bin/hi && \
-    chmod +x /usr/bin/hi
+
+WORKDIR /opt/miner
 
 ENV COOKIE=miner \
     # Write files generated during startup to /tmp
@@ -41,5 +41,3 @@ COPY --from=builder /opt/rel /opt/miner
 
 ENTRYPOINT ["/opt/miner/bin/miner"]
 CMD ["foreground"]
-
-#CMD tail -f /dev/null

--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -34,7 +34,7 @@ RUN echo -e '#!/bin/bash\necho hello' > /usr/bin/hi && \
 ENV COOKIE=miner \
     # Write files generated during startup to /tmp
     RELX_OUT_FILE_PATH=/tmp \
-    # make miner interactions easier
+    # add miner to path, for easy interactions
     PATH=$PATH:/opt/miner/bin
 
 COPY --from=builder /opt/rel /opt/miner

--- a/.buildkite/scripts/Dockerfile-arm32
+++ b/.buildkite/scripts/Dockerfile-arm32
@@ -39,3 +39,7 @@ ENV COOKIE=miner \
 
 COPY --from=builder /opt/rel /opt/miner
 
+ENTRYPOINT ["/opt/miner/bin/miner"]
+CMD ["foreground"]
+
+#CMD tail -f /dev/null

--- a/.buildkite/scripts/Dockerfile-arm32
+++ b/.buildkite/scripts/Dockerfile-arm32
@@ -35,7 +35,9 @@ WORKDIR /opt/miner
 
 ENV COOKIE=miner \
     # Write files generated during startup to /tmp
-    RELX_OUT_FILE_PATH=/tmp
+    RELX_OUT_FILE_PATH=/tmp \
+    # add miner to path, for easy interactions
+    PATH=$PATH:/opt/miner/bin
 
 COPY --from=builder /opt/rel /opt/miner
 

--- a/.buildkite/scripts/Dockerfile-arm32
+++ b/.buildkite/scripts/Dockerfile-arm32
@@ -43,5 +43,3 @@ COPY --from=builder /opt/rel /opt/miner
 
 ENTRYPOINT ["/opt/miner/bin/miner"]
 CMD ["foreground"]
-
-#CMD tail -f /dev/null

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -41,5 +41,3 @@ COPY --from=builder /opt/rel /opt/miner
 
 ENTRYPOINT ["/opt/miner/bin/miner"]
 CMD ["foreground"]
-
-#CMD tail -f /dev/null

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -37,4 +37,7 @@ ENV COOKIE=miner \
 
 COPY --from=builder /opt/rel /opt/miner
 
+ENTRYPOINT ["/opt/miner/bin/miner"]
+CMD ["foreground"]
+
 #CMD tail -f /dev/null

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -33,7 +33,9 @@ WORKDIR /opt/miner
 
 ENV COOKIE=miner \
     # Write files generated during startup to /tmp
-    RELX_OUT_FILE_PATH=/tmp
+    RELX_OUT_FILE_PATH=/tmp \
+    # add miner to path, for easy interactions
+    PATH=$PATH:/opt/miner/bin
 
 COPY --from=builder /opt/rel /opt/miner
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Test
 -----
 
     $ make test
+
+docker
+=====
+
+Build a miner-test image locally:
+
+```
+docker build -t helium:miner-test -f .buildkite/scripts/Dockerfile-xxxNN .
+```


### PR DESCRIPTION
The main changes here are that the miner is run in foreground, allowing `docker run` to return when `-d` option is used.

In addition, `/opt/miner/bin` is added to PATH so that interrogating miner is simpler, ie:

`docker exec happy_lamport miner info height`

rather than 

`docker exec happy_lamport /opt/miner/bin/miner info height`

Also, a teensy bit of documentation is added about how to build a test Docker image locally.

Fuller documentation on the docker will be available on developer.helium.com
