### PR TITLE
update rocks tunings to use more memory

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -56,11 +56,11 @@
      {max_open_files, 128},
      {compaction_style, universal},
      {block_based_table_options, [{cache_index_and_filter_blocks, true}]},
-     {memtable_memory_budget, 4194304},  % 32MB
-     {arena_block_size, 131072}, % 128k
-     {write_buffer_size, 131072},
-     {db_write_buffer_size, 4194304},
-     {max_write_buffer_number, 4},
+     {memtable_memory_budget, 8388608},  % 8MB
+     {arena_block_size, 262144}, % 256kB
+     {write_buffer_size, 262144}, % 256kB
+     {db_write_buffer_size, 8388608}, % 8MB
+     {max_write_buffer_number, 8},
      {keep_log_file_num, 5}
     ]}
   ]},


### PR DESCRIPTION
I think that this should be safe, we cranked these down too low before discovering the batch leak issue.