### PR TITLE
allow region to be supplied via os env var or via sys config

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -28,16 +28,8 @@
    %% dont perform regionalised checks in dev envs
    %% we only realy need the params below if this file is changed to specify a radio device
    %% as without one miner_lora is not started
-   %% including the params anyway in case someone needs it in a dev env
-   {override_reg_domain_check, true},
-   %% use defaults below for dev envs in US / zone 2 locations
-   {default_reg_region, 'US915'},
-   {default_reg_geo_zone, 'zone2'},
-   {default_reg_freq_list, [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3]}
-   %% use defaults below for dev envs in EU / zone 1 locations
-   %%{default_reg_region, 'EU868'},
-   %%{default_reg_geo_zone, 'zone1'},
-   %%{default_reg_freq_list, [867.1, 867.3, 867.5, 867.7, 867.9, 868.1, 868.3, 868.5]}
+   %% including the params anyway in case someone needs it in this env
+   {region_override, 'US915'}
 
   ]}
 ].

--- a/config/test.config
+++ b/config/test.config
@@ -29,15 +29,8 @@
    {stabilization_period_start, 2},
    %% dont perform regionalised checks in test envs
    %% we only realy need the params below if this file is changed to specify a radio device
-   %% OR if a test starts miner_lora manually
-   {override_reg_domain_check, true},
-   %% use defaults below for test envs in US / zone 2 locations
-   {default_reg_region, 'US915'},
-   {default_reg_geo_zone, 'zone2'},
-   {default_reg_freq_list, [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3]}
-   %% use defaults below for test envs in EU / zone 1 locations
-   %%{default_reg_region, 'EU868'},
-   %%{default_reg_geo_zone, 'zone1'},
-   %%{default_reg_freq_list, [867.1, 867.3, 867.5, 867.7, 867.9, 868.1, 868.3, 868.5]}
+   %% as without one miner_lora is not started
+   %% including the params anyway in case someone needs it in this env
+   {region_override, 'US915'}
   ]}
 ].

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -49,7 +49,6 @@
     latlong,
     reg_domain_confirmed = false :: boolean(),
     reg_region :: atom(),
-    reg_geo_zone :: atom(),
     reg_freq_list :: [float()]
 }).
 
@@ -65,7 +64,7 @@
 -type state() :: #state{}.
 -type gateway() :: #gateway{}.
 -type helium_packet() :: #packet_pb{}.
--type freq_data() :: {Region::atom(), GeoZone::atom(), Freqs::[float]}.
+-type freq_data() :: {Region::atom(), Freqs::[float]}.
 
 -define(COUNTRY_FREQ_DATA, country_freq_data).
 
@@ -185,24 +184,28 @@ init(Args) ->
             S
     end,
 
-    %% cloud/miner pro will never assert location and so we dont want to
-    %% use regulatory domain checks for these miners
-    %% allow them to override the regulatory domain checks and be able to transmit from startup
-    %% default region and freq data is expected to be supplied by these miners
-    %% if not we will default to US902-928
-    {RegDomainConfirmed, DefaultRegRegion, DefaultRegGeoZone, DefaultRegFreqList} =
-        case maps:get(override_reg_domain_check, Args, false) of
-            true ->
-                lager:info("overriding regulatory domain checks, using values from Args", []),
-                {true, maps:get(default_reg_region, Args),
-                       maps:get(default_reg_geo_zone, Args),
-                       maps:get(default_reg_freq_list, Args)};
-            _ ->
+    %% cloud/miner pro will never assert location and so we dont  use regulatory domain checks for these miners
+    %% instead they will supply a region value, use this if it exists
+    {RegDomainConfirmed, DefaultRegRegion, DefaultRegFreqList} =
+        case maps:get(region_override, Args, undefined) of
+            undefined ->
                 %% not overriding domain checks, so initialize with source data and defaults
                 ets:new(?COUNTRY_FREQ_DATA, [named_table, public]),
                 ok = init_ets(),
                 erlang:send_after(5000, self(), reg_domain_timeout),
-                {false, undefined, undefined, undefined}
+                {false, undefined, undefined};
+            Region ->
+                lager:info("using region specifed in config: ~p", [Region]),
+                %% get the freq map from config and use Region to get our required data
+                FreqMap = application:get_env(miner, frequency_data, #{}),
+                case maps:get(Region, FreqMap, undefined) of
+                    undefined ->
+                        lager:warning("specified region ~p not supported", [Region]),
+                        {false, undefined, undefined};
+                    FreqList ->
+                        lager:info("using freq list ~p", [FreqList]),
+                        {true, Region, FreqList}
+                end
         end,
     {ok, #state{socket=Socket,
                 sig_fun = maps:get(sig_fun, Args),
@@ -210,7 +213,6 @@ init(Args) ->
                 pubkey_bin = blockchain_swarm:pubkey_bin(),
                 reg_domain_confirmed = RegDomainConfirmed,
                 reg_region = DefaultRegRegion,
-                reg_geo_zone = DefaultRegGeoZone,
                 reg_freq_list = DefaultRegFreqList}}.
 
 handle_call({send, _Payload, _When, _ChannelSelectorFun, _DataRate, _Power, _IPol}, _From,
@@ -310,11 +312,11 @@ handle_info(reg_domain_timeout, #state{reg_domain_confirmed=false, pubkey_bin=Ad
                 %% we will check again after a period
                 erlang:send_after(30000, self(), reg_domain_timeout),
                 {noreply, State};
-            {ok, {Region, GeoZone, FrequencyList}} ->
-                lager:info("confirmed regulatory domain for miner ~p.  region: ~p, geozone: ~p, freqlist: ~p",
-                    [Addr, Region, GeoZone, FrequencyList]),
+            {ok, {Region, FrequencyList}} ->
+                lager:info("confirmed regulatory domain for miner ~p.  region: ~p, freqlist: ~p",
+                    [Addr, Region, FrequencyList]),
                 {noreply, State#state{ reg_domain_confirmed = true, reg_region = Region,
-                        reg_geo_zone = GeoZone, reg_freq_list = FrequencyList}}
+                        reg_freq_list = FrequencyList}}
         end
     catch
         _Type:Exception ->
@@ -605,13 +607,13 @@ country_code_for_addr(Addr)->
 -spec freq_data(#country{}, map())-> {ok, freq_data()}.
 freq_data(#country{region = undefined} = _Country, _FreqMap)->
     {error, region_not_set};
-freq_data(#country{region = Region, geo_zone = Zone}= _Country, FreqMap)->
+freq_data(#country{region = Region}= _Country, FreqMap)->
     case maps:get(Region, FreqMap, undefined) of
         undefined ->
             lager:warning("frequency data not found for region ~p",[Region]),
             {error, frequency_not_found_for_region};
         F->
-            {ok, {Region, Zone, F}}
+            {ok, {Region, F}}
     end.
 
 -spec init_ets() -> ok.

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -630,10 +630,7 @@ init_per_testcase(Mod, TestCase, Config0) ->
                 ct_rpc:call(Miner, application, set_env, [miner, radio_device, {{127,0,0,1}, UDPPort, {127,0,0,1}, TCPPort}]),
                 ct_rpc:call(Miner, application, set_env, [miner, stabilization_period_start, 2]),
                 ct_rpc:call(Miner, application, set_env, [miner, default_routers, [DefaultRouters]]),
-                ct_rpc:call(Miner, application, set_env, [miner, override_reg_domain_check, true]),
-                ct_rpc:call(Miner, application, set_env, [miner, default_reg_region, 'US915']),
-                ct_rpc:call(Miner, application, set_env, [miner, default_reg_geo_zone, 'zone2']),
-                ct_rpc:call(Miner, application, set_env, [miner, default_reg_freq_list, [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3]]),
+                ct_rpc:call(Miner, application, set_env, [miner, region_override, 'US915']),
                 {ok, _StartedApps} = ct_rpc:call(Miner, application, ensure_all_started, [miner]),
             ok
         end,

--- a/test/miner_onion_SUITE.erl
+++ b/test/miner_onion_SUITE.erl
@@ -79,10 +79,7 @@ basic(Config) ->
         radio_udp_send_ip => {127,0,0,1},
         radio_udp_send_port => Port,
         sig_fun => libp2p_crypto:mk_sig_fun(PrivateKey),
-        override_reg_domain_check => true,
-        default_reg_region => 'US915',
-        default_reg_geo_zone => 'zone2',
-        default_reg_freq_list => [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3]
+        region_override => 'US915'
     }),
 
 
@@ -161,10 +158,7 @@ basic(Config) ->
         radio_udp_send_ip => {127,0,0,1},
         radio_udp_send_port => Port,
         sig_fun => libp2p_crypto:mk_sig_fun(PrivateKey2),
-        override_reg_domain_check => true,
-        default_reg_region => 'US915',
-        default_reg_geo_zone => 'zone2',
-        default_reg_freq_list => [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3]
+        region_override => 'US915'
     }),
 
     %% set up the gateway


### PR DESCRIPTION
This enables the operating region to be supplied via the sys config or directly via an os level env var.  The sys config value will take precedence.  If the region is not supplied via either of these two options, miner will attempt to derive the region from the asserted location ( no changes there ).

the expected application env var in sys config is 'region_override'
the expected OS env var is 'REGION_OVERRIDE'

Valid values for both are:

US915 | EU868 | EU433 | CN470 |  CN779 | AU915 | AS923 | KR920 | IN865

The OS env var is not templated in the sys config file as doing so necessities the env var having to exist/be set otherwise the sys config file will not derive a value for the key and thus fail to boot.  I didnt want to make setting the env var a pre-requisite.   I can make it a pre-requisite for prod releases only but even then I dont think its a good idea to do so.  In the current implementation we check for the env var from the code ( rather than expecting it as an application env var ) and if it exists we use it, if not exists then ignore it. 

