### PR TITLE
Add downlink throttling

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -49,7 +49,8 @@
     latlong,
     reg_domain_confirmed = false :: boolean(),
     reg_region :: atom(),
-    reg_freq_list :: [float()]
+    reg_freq_list :: [float()],
+    reg_throttle :: miner_lora_throttle:handle()
 }).
 
 -record(country, {
@@ -204,7 +205,8 @@ init(Args) ->
                 pubkey_bin = blockchain_swarm:pubkey_bin(),
                 reg_domain_confirmed = RegDomainConfirmed,
                 reg_region = DefaultRegRegion,
-                reg_freq_list = DefaultRegFreqList}}.
+                reg_freq_list = DefaultRegFreqList,
+                reg_throttle = miner_lora_throttle:new(DefaultRegRegion)}}.
 
 handle_call({send, _Payload, _When, _ChannelSelectorFun, _DataRate, _Power, _IPol}, _From,
                 #state{reg_domain_confirmed = false}=State) ->
@@ -214,7 +216,8 @@ handle_call({send, Payload, When, ChannelSelectorFun, DataRate, Power, IPol}, Fr
                 #state{ socket=Socket,
                         gateways=Gateways,
                         packet_timers=Timers,
-                        reg_freq_list = Freqs}=State) ->
+                        reg_freq_list = Freqs,
+                        reg_throttle = Throttle}=State) ->
     case select_gateway(Gateways) of
         {error, _}=Error ->
             {reply, Error, State};
@@ -222,7 +225,20 @@ handle_call({send, Payload, When, ChannelSelectorFun, DataRate, Power, IPol}, Fr
             %% the fun is set by the sender and is used to deterministically route data via channels
             LocalFreq = ChannelSelectorFun(Freqs),
             Token = mk_token(Timers),
-            %% TODO we should check this for regulatory compliance
+
+            %% Check this transmission for regulatory compliance.
+            {SpreadingFactor, Bandwidth} = parse_datarate(DataRate),
+            TimeOnAir = miner_lora_throttle:time_on_air(Bandwidth, SpreadingFactor, 5, 8, true, byte_size(Payload)),
+            %% TODO: replace `monotonic_time' with monotonic time derived from concentrator's counter.
+            %%
+            %% It's not as simple as it sounds because the counter is only 32 bits
+            %% and rolls over every 134 seconds.
+            SentAt = erlang:monotonic_time(millisecond),
+            case miner_lora_reg:can_send(Throttle, SentAt, LocalFreq, TimeOnAir) of
+                false -> lager:notice("This transmission should have been rejected");
+                true -> ok
+            end,
+
             BinJSX = jsx:encode(
                        #{<<"txpk">> => #{
                              %% IPol for downlink to devices only, not poc packets
@@ -246,7 +262,7 @@ handle_call({send, Payload, When, ChannelSelectorFun, DataRate, Power, IPol}, Fr
             ok = gen_udp:send(Socket, IP, Port, Packet),
             %% TODO a better timeout would be good here
             Ref = erlang:send_after(10000, self(), {tx_timeout, Token}),
-            {noreply, State#state{packet_timers=maps:put(Token, {send, Ref, From}, Timers)}}
+            {noreply, State#state{packet_timers = maps:put(Token, {send, Ref, From, SentAt, LocalFreq, TimeOnAir}, Timers)}}
     end;
 handle_call(port, _From, State) ->
     {reply, inet:port(State#state.socket), State};
@@ -306,7 +322,7 @@ handle_info(reg_domain_timeout, #state{reg_domain_confirmed=false, pubkey_bin=Ad
                 lager:info("confirmed regulatory domain for miner ~p.  region: ~p, freqlist: ~p",
                     [Addr, Region, FrequencyList]),
                 {noreply, State#state{ reg_domain_confirmed = true, reg_region = Region,
-                        reg_freq_list = FrequencyList}}
+                        reg_freq_list = FrequencyList, reg_throttle = miner_lora_throttle:new(Region)}}
         end
     catch
         _Type:Exception ->
@@ -316,7 +332,7 @@ handle_info(reg_domain_timeout, #state{reg_domain_confirmed=false, pubkey_bin=Ad
     end;
 handle_info({tx_timeout, Token}, #state{packet_timers=Timers}=State) ->
     case maps:find(Token, Timers) of
-        {ok, {send, _Ref, From}} ->
+        {ok, {send, _Ref, From, _SentAt, _LocalFreq, _TimeOnAir}} ->
             gen_server:reply(From, {error, timeout});
         error ->
             ok
@@ -407,46 +423,47 @@ handle_udp_packet(<<?PROTOCOL_2:8/integer-unsigned,
                     Token:2/binary,
                     ?TX_ACK:8/integer-unsigned,
                     _MAC:64/integer,
-                    MaybeJSON/binary>>, _IP, _Port, #state{packet_timers=Timers}=State) ->
+                    MaybeJSON/binary>>, _IP, _Port, #state{packet_timers=Timers, reg_throttle=Throttle}=State) ->
     lager:info("TX ack for token ~p ~p", [Token, MaybeJSON]),
     case maps:find(Token, Timers) of
-        {ok, {send, Ref, From}} when MaybeJSON == <<>> -> %% empty string means success, at least with the semtech reference implementation
+        {ok, {send, Ref, From, SentAt, LocalFreq, TimeOnAir}} when MaybeJSON == <<>> -> %% empty string means success, at least with the semtech reference implementation
             _ = erlang:cancel_timer(Ref),
             _ = gen_server:reply(From, ok),
-            State#state{packet_timers=maps:remove(Token, Timers)};
-        {ok, {send, Ref, From}} ->
+            State#state{packet_timers=maps:remove(Token, Timers),
+                        reg_throttle=miner_lora_throttle:track_sent(Throttle, SentAt, LocalFreq, TimeOnAir)};
+        {ok, {send, Ref, From, SentAt, LocalFreq, TimeOnAir}} ->
             %% likely some kind of error here
             _ = erlang:cancel_timer(Ref),
-            Reply = case kvc:path([<<"txpk_ack">>, <<"error">>], jsx:decode(MaybeJSON)) of
+            {Reply, NewThrottle} = case kvc:path([<<"txpk_ack">>, <<"error">>], jsx:decode(MaybeJSON)) of
                 <<"NONE">> ->
                     lager:info("packet sent ok"),
-                    ok;
+                    {ok, miner_lora_throttle:track_sent(Throttle, SentAt, LocalFreq, TimeOnAir)};
                 <<"COLLISION_", _/binary>> ->
                     %% colliding with a beacon or another packet, check if join2/rx2 is OK
                     lager:info("collision"),
-                    {error, collision};
+                    {{error, collision}, Throttle};
                 <<"TOO_LATE">> ->
                     lager:info("too late"),
-                    {error, too_late};
+                    {{error, too_late}, Throttle};
                 <<"TOO_EARLY">> ->
                     lager:info("too early"),
-                    {error, too_early};
+                    {{error, too_early}, Throttle};
                 <<"TX_FREQ">> ->
                     lager:info("tx frequency not supported"),
                     {error, bad_tx_frequency};
                 <<"TX_POWER">> ->
                     lager:info("tx power not supported"),
-                    {error, bad_tx_power};
+                    {{error, bad_tx_power}, Throttle};
                 <<"GPL_UNLOCKED">> ->
                     lager:info("transmitting on GPS time not supported because no GPS lock"),
-                    {error, no_gps_lock};
+                    {{error, no_gps_lock}, Throttle};
                 Error ->
                     %% any other errors are pretty severe
                     lager:error("Failure enqueing packet for gateway ~p", [Error]),
-                    {error, {unknown, Error}}
+                    {{error, {unknown, Error}}, Throttle}
             end,
             gen_server:reply(From, Reply),
-            State#state{packet_timers=maps:remove(Token, Timers)};
+            State#state{packet_timers=maps:remove(Token, Timers), reg_throttle=NewThrottle};
         error ->
             State
     end;
@@ -632,3 +649,16 @@ csv_rows_to_ets(F) ->
             lager:warning("failed to read file ~p, error: ~p", [F, Reason]),
             {error, Reason}
   end.
+
+%% @doc returns a tuple of {SpreadingFactor, Bandwidth} from strings like "SFdBWddd"
+%%
+%% Example: `{7, 125} = scratch:parse_datarate("SF7BW125")'
+
+-spec parse_datarate(string()) -> {integer(), integer()}.
+parse_datarate(Datarate) ->
+    case Datarate of
+        [$S, $F, SF1, SF2, $B, $W, BW1, BW2, BW3] ->
+            {erlang:list_to_integer([SF1, SF2]), erlang:list_to_integer([BW1, BW2, BW3])};
+        [$S, $F, SF1, $B, $W, BW1, BW2, BW3] ->
+            {erlang:list_to_integer([SF1]), erlang:list_to_integer([BW1, BW2, BW3])}
+    end.

--- a/src/miner_lora_throttle.erl
+++ b/src/miner_lora_throttle.erl
@@ -1,0 +1,235 @@
+%% @doc This module provides time-on-air regulatory compliance for the
+%% EU868 and US915 ISM bands.
+%%
+%% This module does not interface with hardware or provide any
+%% transmission capabilities itself. Instead, the API provides its
+%% core functionality through `track_sent/4', `can_send/4', and
+%% `time_on_air/6'.
+-module(miner_lora_throttle).
+
+-export([
+    can_send/4,
+    dwell_time/3,
+    dwell_time_period/1,
+    max_dwell_time/1,
+    new/1,
+    time_on_air/6,
+    track_sent/9,
+    track_sent/4
+]).
+
+-export_type([
+    region/0,
+    handle/0
+]).
+
+-record(sent_packet, {
+    sent_at :: number(),
+    time_on_air :: number(),
+    frequency :: number()
+}).
+
+-type region() :: 'EU868' | 'US915'.
+
+-opaque handle() :: {region(), list(#sent_packet{})}.
+
+%% @doc Time over which we keep sent packet statistics for duty-cycle
+%% limited regions (EU868).
+%%
+%% In order to calculate duty cycle, we track every single
+%% transmission 'now' and the previous DUTY_CYCLE_PERIOD_MS of
+%% time. Note that 'now' is always changing and that transmissions
+%% older than DUTY_CYCLE_PERIOD_MS are only untracked when updating
+%% state or calculating duty-cycle.
+-define(DUTY_CYCLE_PERIOD_MS, 3600000).
+
+%% Maximum time on air for dell-time limited regions (US915).
+%%
+%% See 47 CFR 15.247.
+-define(MAX_DWELL_TIME_MS, 400).
+
+%% Time over which enforce MAX_DWELL_TIME_MS.
+-define(DWELL_TIME_PERIOD_MS, 20000).
+
+%% Updates Handle with time-on-air information.
+%%
+%% This function does not send/transmit itself.
+-spec track_sent(
+    Handle :: handle(),
+    SentAt :: number(),
+    Frequency :: number(),
+    Bandwidth :: number(),
+    SpreadingFactor :: integer(),
+    CodeRate :: integer(),
+    PreambleSymbols :: integer(),
+    ExplicitHeader :: boolean(),
+    PayloadLen :: integer()
+) ->
+    handle().
+track_sent(
+    Handle,
+    SentAt,
+    Frequency,
+    Bandwidth,
+    SpreadingFactor,
+    CodeRate,
+    PreambleSymbols,
+    ExplicitHeader,
+    PayloadLen
+) ->
+    TimeOnAir = time_on_air(
+        Bandwidth,
+        SpreadingFactor,
+        CodeRate,
+        PreambleSymbols,
+        ExplicitHeader,
+        PayloadLen
+    ),
+    track_sent(Handle, SentAt, Frequency, TimeOnAir).
+
+-spec track_sent(handle(), number(), number(), number()) -> handle().
+track_sent({Region, SentPackets}, SentAt, Frequency, TimeOnAir) ->
+    NewSent = #sent_packet{
+        frequency = Frequency,
+        sent_at = SentAt,
+        time_on_air = TimeOnAir
+    },
+    {Region, trim_sent(Region, [NewSent | SentPackets])}.
+
+-spec trim_sent(region(), list(#sent_packet{})) -> list(#sent_packet{}).
+trim_sent(Region, SentPackets = [NewSent, LastSent | _])
+        when NewSent#sent_packet.sent_at < LastSent#sent_packet.sent_at ->
+    trim_sent(Region, lists:sort(fun (A, B) -> A > B end, SentPackets));
+trim_sent('US915', SentPackets = [H | _]) ->
+    CutoffTime = H#sent_packet.sent_at - ?DWELL_TIME_PERIOD_MS,
+    Pred = fun (Sent) -> Sent#sent_packet.sent_at > CutoffTime end,
+    lists:takewhile(Pred, SentPackets);
+trim_sent('EU868', SentPackets = [H | _]) ->
+    CutoffTime = H#sent_packet.sent_at - ?DUTY_CYCLE_PERIOD_MS,
+    Pred = fun (Sent) -> Sent#sent_packet.sent_at > CutoffTime end,
+    lists:takewhile(Pred, SentPackets).
+
+%% @doc Based on previously sent packets, returns a boolean value if
+%% it is legal to send on Frequency at time Now.
+%%
+%%
+-spec can_send(
+    Handle :: handle(),
+    AtTime :: number(),
+    Frequency :: integer(),
+    TimeOnAir :: number()
+) ->
+    boolean().
+can_send(_Handle, _AtTime, _Frequency, TimeOnAir) when TimeOnAir > ?MAX_DWELL_TIME_MS ->
+    %% TODO: double check that ETSI's max time on air is the same as
+    %% FCC.
+    false;
+can_send({'US915', SentPackets}, AtTime, Frequency, TimeOnAir) ->
+    CutoffTime = AtTime - ?DWELL_TIME_PERIOD_MS + TimeOnAir,
+    ProjectedDwellTime = dwell_time(SentPackets, CutoffTime, Frequency) + TimeOnAir,
+    ProjectedDwellTime =< ?MAX_DWELL_TIME_MS;
+can_send({'EU868', SentPackets}, AtTime, Frequency, TimeOnAir) ->
+    CutoffTime = AtTime - ?DUTY_CYCLE_PERIOD_MS,
+    CurrDwell = dwell_time(SentPackets, CutoffTime, Frequency),
+    OnePercent = 0.01,
+    (CurrDwell + TimeOnAir) / ?DUTY_CYCLE_PERIOD_MS < OnePercent.
+
+%% @doc Computes the total time on air for packets sent on Frequency
+%% and no older than CutoffTime.
+-spec dwell_time(list(#sent_packet{}), integer(), number()) -> number().
+dwell_time(SentPackets, CutoffTime, Frequency) ->
+    dwell_time(SentPackets, CutoffTime, Frequency, 0).
+
+-spec dwell_time(list(#sent_packet{}), integer(), number(), number()) -> number().
+%% Scenario 1: entire packet sent before CutoffTime
+dwell_time([P | T], CutoffTime, Frequency, Acc)
+        when P#sent_packet.sent_at + P#sent_packet.time_on_air < CutoffTime ->
+    dwell_time(T, CutoffTime, Frequency, Acc);
+%% Scenario 2: packet sent on non-relevant frequency.
+dwell_time([P | T], CutoffTime, Frequency, Acc) when P#sent_packet.frequency /= Frequency ->
+    dwell_time(T, CutoffTime, Frequency, Acc);
+%% Scenario 3: Packet started before CutoffTime but finished after CutoffTime.
+dwell_time([P | T], CutoffTime, Frequency, Acc) when P#sent_packet.sent_at =< CutoffTime ->
+    RelevantTimeOnAir = P#sent_packet.time_on_air - (CutoffTime - P#sent_packet.sent_at),
+    true = RelevantTimeOnAir >= 0,
+    dwell_time(T, CutoffTime, Frequency, Acc + RelevantTimeOnAir);
+%% Scenario 4: 100 % of packet transmission after CutoffTime.
+dwell_time([P | T], CutoffTime, Frequency, Acc) ->
+    dwell_time(T, CutoffTime, Frequency, Acc + P#sent_packet.time_on_air);
+dwell_time([], _CutoffTime, _Frequency, Acc) ->
+    Acc.
+
+%% @doc Returns total time on air for packet sent with given
+%% parameters.
+%%
+%% See Semtech Appnote AN1200.13, "LoRa Modem Designer's Guide"
+-spec time_on_air(
+    Bandwidth :: number(),
+    SpreadingFactor :: number(),
+    CodeRate :: integer(),
+    PreambleSymbols :: integer(),
+    ExplicitHeader :: boolean(),
+    PayloadLen :: integer()
+) ->
+    Milliseconds :: float().
+time_on_air(
+    Bandwidth,
+    SpreadingFactor,
+    CodeRate,
+    PreambleSymbols,
+    ExplicitHeader,
+    PayloadLen
+) ->
+    SymbolDuration = symbol_duration(Bandwidth, SpreadingFactor),
+    PayloadSymbols = payload_symbols(
+        SpreadingFactor,
+        CodeRate,
+        ExplicitHeader,
+        PayloadLen,
+        (Bandwidth =< 125000) and (SpreadingFactor >= 11)
+    ),
+    SymbolDuration * (4.25 + PreambleSymbols + PayloadSymbols).
+
+%% @doc Returns the number of payload symbols required to send payload.
+-spec payload_symbols(integer(), integer(), boolean(), integer(), boolean()) -> number().
+payload_symbols(
+    SpreadingFactor,
+    CodeRate,
+    ExplicitHeader,
+    PayloadLen,
+    LowDatarateOptimized
+) ->
+    EH = b2n(ExplicitHeader),
+    LDO = b2n(LowDatarateOptimized),
+    8 +
+        (erlang:max(
+            math:ceil(
+                (8 * PayloadLen - 4 * SpreadingFactor + 28 +
+                    16 - 20 * (1 - EH)) /
+                    (4 * (SpreadingFactor - 2 * LDO))
+            ) * (CodeRate),
+            0
+        )).
+
+-spec symbol_duration(number(), number()) -> float().
+symbol_duration(Bandwidth, SpreadingFactor) ->
+    math:pow(2, SpreadingFactor) / Bandwidth.
+
+%% @doc Returns a new handle for the given region.
+-spec new(Region :: region()) -> handle().
+new('EU868') ->
+    {'EU868', []};
+new('US915') ->
+    {'US915', []}.
+
+-spec b2n(boolean()) -> integer().
+b2n(false) ->
+    0;
+b2n(true) ->
+    1.
+
+dwell_time_period(Unit) ->
+    erlang:convert_time_unit(?DWELL_TIME_PERIOD_MS, millisecond, Unit).
+
+max_dwell_time(Unit) ->
+    erlang:convert_time_unit(?MAX_DWELL_TIME_MS, millisecond, Unit).


### PR DESCRIPTION
This PR adds region-aware enforcement of transmission restrictions.

## Still needed

- [ ] EU868 is definitely not correct. I'm still a little fuzzy on ETSI duty-cycle rules, and some subbands allow more/less duty-cycle than others
- [ ] US915 should take into account TX bandwidth. Right now the throttle considers the 400ms dwell time over 20s, but that can be reduced to 400ms over 10s for transmissions at bandwidth >=250 kHz
