### PR TITLE
Bump blessed snapshot to 417601

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -22,9 +22,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 407521},
+   {blessed_snapshot_block_height, 417601},
    {blessed_snapshot_block_hash,
-    <<14,196,182,77,149,18,208,15,23,98,199,126,160,64,80,206,122,207,202,182,239,121,147,70,61,242,192,55,252,72,192,189>>},
+    <<115,116,117,15,101,91,238,141,114,6,155,94,229,3,60,14,94,22,34,100,42,190,162,59,62,34,194,129,170,93,122,228>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
# miner snapshot list
Height 417601
Hash <<115,116,117,15,101,91,238,141,114,6,155,94,229,3,60,14,94,22,34,100,42,
       190,162,59,62,34,194,129,170,93,122,228>>
Have true
```