### PR TITLE
Bump core for empty Payer58

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"b47f0e8b5995c523bd94d5fea40cb084b49c9163"}},
+       {ref,"50377e8e2fb37b7c9259835390d169e8bda8515a"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
This should allow users to re-assert their Hotspot's location from the mobile app.