### PR TITLE
Prevent dropped downlink packets

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -381,7 +381,11 @@ handle_udp_packet(<<?PROTOCOL_2:8/integer-unsigned,
     Gateway =
         case maps:find(MAC, Gateways) of
             {ok, #gateway{received=Received}=G} ->
-                G#gateway{ip=IP, port=Port, received=Received+1};
+                %% We purposely do not update gateway's addr/port
+                %% here. They should only be updated when handling
+                %% PULL_DATA, otherwise we may send downlink packets
+                %% to the wrong place.
+                G#gateway{received=Received+1};
             error ->
                 #gateway{mac=MAC, ip=IP, port=Port, received=1}
         end,


### PR DESCRIPTION
We are dropping a non-negligible number of downlink lora packets due to the way we track a gateway's UDP port. The Semtech packet forwarder opens two sockets, one for pushing messages to the server, and one for pulling. We currently update the source port on both PUSH_DATA and PULL_DATA messages. This has the adverse effect of miner sending downlink packets to the wrong port after receiving PUSH_DATA messages. Instead, we should only track the source port for PULL_DATA while still sending PUSH_ACKs to their correct port.