### PR TITLE
Updates for state channel causality fixes

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"57dfd5c2f7a0f622165b88f14d9567a3c74b3e10"}},
+       {ref,"bef56fae81be8556ce4941b6a49a60c1ffa2ad54"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",

--- a/test/miner_state_channel_SUITE.erl
+++ b/test/miner_state_channel_SUITE.erl
@@ -70,7 +70,9 @@ init_per_group(sc_v2, Config) ->
     SCV2Vars = maps:merge(SCVars,
                           #{?sc_version => 2,
                             ?sc_overcommit => 2,
-                            ?election_interval => 30
+                            ?election_interval => 30,
+                            ?sc_open_validation_bugfix => 1,
+                            ?sc_causality_fix => 1
                            }),
     [{sc_vars, SCV2Vars}, {sc_version, 2} | Config].
 


### PR DESCRIPTION
Core PR: https://github.com/helium/blockchain-core/pull/550

Confirmed resync with validation from height: 434161 (just before first sc_v2 activation).