### PR TITLE
Add .dockerignore with _build directory

### DIFF
--- a/.buildkite/scripts/.dockerignore
+++ b/.buildkite/scripts/.dockerignore
@@ -1,0 +1,3 @@
+# files and directories to exclude from context
+_build
+

--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -14,7 +14,6 @@ ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" \
 # Add our code
 ADD . /usr/src/miner/
 
-RUN rm -rf _build
 RUN rebar3 as prod tar
 RUN mkdir -p /opt/rel
 RUN tar -zxvf _build/prod/rel/*/*.tar.gz -C /opt/rel

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -14,7 +14,6 @@ ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" \
 # Add our code
 ADD . /usr/src/miner/
 
-RUN rm -rf _build
 RUN rebar3 as prod tar
 RUN mkdir -p /opt/rel
 RUN tar -zxvf _build/prod/rel/*/*.tar.gz -C /opt/rel


### PR DESCRIPTION
The Docker image build fails if no `_build` directory already exists. Instead of `RUN rm -rf _build` the best practice according to those in the know is to add a `.dockerignore` file with `_build` in it.