### PR TITLE
Read onboarding_key from file on Blackspots

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -36,6 +36,7 @@
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},
+   {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
    {seed_nodes, "/ip4/34.222.64.221/tcp/2154,/ip4/34.208.255.251/tcp/2154"},
    {seed_node_dns, "seed.helium.foundation"},


### PR DESCRIPTION
The Blackspots that RAK is manufacturing for the Helium Network will come with a version 4 UUID written to an `onboarding_key` file on the boot partition of the microSD card.

```
# cat /etc/hardware_version 
blackspot
# cat /mnt/uboot/onboarding_key 
e8d57c09f96c41229ff34f8889504a05
# miner print_keys
{pubkey,"11k4Gn6Qhs6JDet1w1fKxUe647zw4KRiZCYhNBtqYCL16BNmjRo"}.
{onboarding_key,"e8d57c09f96c41229ff34f8889504a05"}.
{animal_name,"decent-tortilla-bee"}.
```

Notice that the `onboarding_key` displayed for a Blackspot is no longer `undefined` when a `/mnt/uboot/onboarding_key` file exists.