### PR TITLE
Bump blessed snapshot to height 475921

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -30,9 +30,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 468721},
+   {blessed_snapshot_block_height, 475921},
    {blessed_snapshot_block_hash,
-    <<87,74,66,183,209,50,51,113,153,250,112,176,6,49,75,59,208,212,111,2,66,208,90,2,140,87,112,185,27,7,246,184>>},
+    <<208,73,146,223,228,71,202,161,17,246,111,134,211,250,40,85,129,245,112,48,151,57,190,37,114,145,157,225,194,38,1,183>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
# miner snapshot list
Height 475921
Hash <<208,73,146,223,228,71,202,161,17,246,111,134,211,250,40,85,129,245,112,
       48,151,57,190,37,114,145,157,225,194,38,1,183>>
Have true
```