### PR TITLE
upgrade lager, use new pterm feature to include os pid

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -14,7 +14,12 @@
    {metadata_whitelist, [poc_id]},
    {handlers,
     [
-     {lager_file_backend, [{file, "console.log"}, {level, info}]},
+     {lager_file_backend, [{file, "console.log"}, {level, info},
+                           {formatter, lager_default_formatter},
+                           {formatter_config, [date, " ", time, " ", {pterm, ospid, <<"NOPID">>},
+                                               " [",severity,"] ",
+                                               pid, "@", module, ":", function, ":", line, " ",
+                                               message, "\n"]}]},
      {lager_file_backend, [{file, "error.log"}, {level, error}]}
     ]}
   ]},

--- a/src/miner_app.erl
+++ b/src/miner_app.erl
@@ -16,6 +16,8 @@
 
 start(_StartType, _StartArgs) ->
 
+    persistent_term:put(ospid, os:getpid()),
+
     GlobalOpts = application:get_env(rocksdb, global_opts, []),
     {ok, Cache} = rocksdb:new_cache(lru, 4 * 1024 * 1024),
     {ok, BufferMgr} = rocksdb:new_write_buffer_manager(4 * 1024 * 1024, Cache),


### PR DESCRIPTION
it's sometimes hard to tell when a node reboots on hotspots, so use the lager pterm feature to cache the os pid for inclusion in the logs.