### PR TITLE
Bump blessed snapshot to height 498961

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 487441},
+   {blessed_snapshot_block_height, 498961},
    {blessed_snapshot_block_hash,
-    <<120,49,194,37,34,239,244,250,148,194,90,207,176,242,171,86,31,23,191,77,221,106,248,246,17,43,189,34,202,249,90,98>>},
+    <<187,98,112,202,202,35,102,203,98,12,16,120,12,216,24,188,223,66,65,40,61,162,124,63,64,194,74,224,103,80,123,109>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
# miner snapshot list
Height 498961
Hash <<187,98,112,202,202,35,102,203,98,12,16,120,12,216,24,188,223,66,65,40,
       61,162,124,63,64,194,74,224,103,80,123,109>>
Have true
```