### PR TITLE
Bump blessed snapshot to height 509761

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 503281},
+   {blessed_snapshot_block_height, 509761},
    {blessed_snapshot_block_hash,
-    <<155,29,179,97,159,127,85,110,227,126,0,54,128,74,189,90,229,242,119,224,62,113,33,89,49,16,246,237,174,104,21,253>>},
+    <<29,124,235,165,32,68,185,42,65,26,83,24,41,170,196,153,184,122,75,8,245,10,190,114,63,225,96,7,231,230,110,21>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
# miner snapshot list
Height 509761
Hash <<29,124,235,165,32,68,185,42,65,26,83,24,41,170,196,153,184,122,75,8,245,
       10,190,114,63,225,96,7,231,230,110,21>>
Have true
```