### PR TITLE
Add a Docker Tag for latest-arch

### DIFF
--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -15,3 +15,5 @@ docker login -u="team-helium+buildkite" -p="${QUAY_BUILDKITE_PASSWORD}" ${REGIST
 docker build -t helium:$DOCKER_NAME -f "${DOCKERFILE_NAME}" .
 docker tag helium:$DOCKER_NAME "$MINER_REGISTRY_NAME:$DOCKER_NAME"
 docker push "$MINER_REGISTRY_NAME:$DOCKER_NAME"
+docker tag helium:$DOCKER_NAME "$MINER_REGISTRY_NAME:latest-${IMAGE_ARCH}"
+docker push "$MINER_REGISTRY_NAME:latest-${IMAGE_ARCH}"


### PR DESCRIPTION
Docker has a `latest` tag that is generally applied to repositories for the latest "GA" image. Community has been asking for this in some shape or form. I am thinking of PastaGringo in particular and @jamiew today exclaimed: "My kingdom for a ‘latest’ tag on quay".  Indeed, it would greatly simplify [scripts ](https://github.com/Wheaties466/helium_miner_scripts) meant to keep the service up to date.

In our case, our repository has Dockers for two architectures and so simply `latest` will not do. 

We could 
- split the repository, such that `https://quay.io/repository/team-helium/miner-amd64` and `https://quay.io/repository/team-helium/miner-arm64` exist
- append the architecture to the `latest` tag, such that tags `latest-amd64` and `latest-arm64` exist

The latter is less work, thus it is what I propose here. 

For testing, I created a presonal quay repository and tested the commands in this PR. My main concern was whether a previous tag could be overwritten without removing from the previous image as the documentation for [`docker tag`](https://docs.docker.com/engine/reference/commandline/tag/) was not explicit about this.

The first upload:

![first_tag](https://user-images.githubusercontent.com/1606640/93942065-89a11600-fce4-11ea-81e0-168e0ea764a2.png)

The second upload:

![second_tag](https://user-images.githubusercontent.com/1606640/93942163-b81ef100-fce4-11ea-96b0-f3b4d6d24aa6.png)

This appears to validate that it does overwrite the tag without much fuss.

