### PR TITLE
Dynamically select spreading factor for PoC packets

### DIFF
--- a/audit/var-45.md
+++ b/audit/var-45.md
@@ -1,4 +1,4 @@
-# Chain Variable Transaction 45
+# Chain Variable Transaction 44
 
 ## Changes
 

--- a/audit/var-45.md
+++ b/audit/var-45.md
@@ -1,4 +1,4 @@
-# Chain Variable Transaction 44
+# Chain Variable Transaction 45
 
 ## Changes
 

--- a/src/poc/miner_onion_server.erl
+++ b/src/poc/miner_onion_server.erl
@@ -403,4 +403,4 @@ spreading(Len) when Len < 243 ->
     "SF7BW125";
 spreading(_) ->
     %% onion packets won't be this big, but this will top out around 180 bytes
-    "SF8BW500".
+    "SF7BW125".

--- a/src/poc/miner_onion_server.erl
+++ b/src/poc/miner_onion_server.erl
@@ -345,7 +345,8 @@ decrypt(Type, IV, OnionCompactKey, Tag, CipherText, RSSI, SNR, Frequency, Channe
                 true ->
                     %% the fun below will be executed by miner_lora:send and supplied with the localised lists of channels
                     ChannelSelectorFun = fun(FreqList) -> lists:nth((IntData rem 8) + 1, FreqList) end,
-                    erlang:spawn(fun() -> miner_lora:send_poc(Packet, immediate, ChannelSelectorFun, "SF10BW125", ?TX_POWER) end),
+                    Spreading = spreading(erlang:byte_size(Packet)),
+                    erlang:spawn(fun() -> miner_lora:send_poc(Packet, immediate, ChannelSelectorFun, Spreading, ?TX_POWER) end),
                     erlang:spawn(fun() -> ?MODULE:send_receipt(Data, OnionCompactKey, Type, os:system_time(nanosecond),
                                                                RSSI, SNR, Frequency, Channel, DataRate, Stream, State) end);
                 false ->
@@ -391,3 +392,15 @@ try_decrypt(IV, OnionCompactKey, OnionKeyHash, Tag, CipherText, ECDHFun, Chain) 
             {error, too_many_pocs}
     end.
 
+-spec spreading(integer()) -> string().
+spreading(Len) when Len < 12 ->
+    "SF10BW125";
+spreading(Len) when Len < 54 ->
+    "SF9BW125";
+spreading(Len) when Len < 126 ->
+    "SF8BW125";
+spreading(Len) when Len < 243 ->
+    "SF7BW125";
+spreading(_) ->
+    %% onion packets won't be this big, but this will top out around 180 bytes
+    "SF8BW500".


### PR DESCRIPTION
As Proof of Coverage onion packets are variable in size (based on the path length), we should dynamically select the correct spreading factor based on the packet size to ensure compliance with the LoRaWAN specification and any regional regulations. 