### PR TITLE
reduce the time period, be more aggressive about catchup

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -92,7 +92,7 @@
                     {127,0,0,1}, 31341} },
    {default_routers, ["/p2p/112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE", "/p2p/1124CJ9yJaHq4D6ugyPCDnSBzQik61C1BqD9VMh1vsUmjwt16HNB"]},
    {mark_mods, [miner_hbbft_handler]},
-   {stabilization_period, 100000},
+   {stabilization_period, 50000},
    {reg_domains_file, "countries_reg_domains.csv"},
    {frequency_data, #{'US915' => [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3],
                       'EU868' => [867.1, 867.3, 867.5, 867.7, 867.9, 868.1, 868.3, 868.5],

--- a/src/miner.erl
+++ b/src/miner.erl
@@ -623,9 +623,9 @@ set_next_block_timer(State=#state{blockchain=Chain}) ->
     BlockTimeDeviation =
         case BlockTimeDeviation0 of
             N when N > 0 ->
-                catchup_time(N);
+                catchup_time(abs(N));
             N ->
-                -1 * catchup_time(N)
+                -1 * catchup_time(abs(N))
         end,
     NextBlockTime = max(0, (LastBlockTimestamp + BlockTime + BlockTimeDeviation) - Now),
     lager:info("Next block after ~p is in ~p seconds", [LastBlockTimestamp, NextBlockTime]),
@@ -650,7 +650,22 @@ process_bbas(N, BBAs) ->
             end
     end.
 
-catchup_time(N) when N < 0.15 ->
+%% input in fractional seconds, the number of seconds between the
+%% target block time and the average total time over the target period
+%% output in seconds of adjustment to apply to the block time target
+
+%% the constants here are by feel: currently at 100k target and 5sec
+%% adjustment it takes roughly a day of blocks to make up a tenth of a
+%% second. with the new 50k target we can expect double the adjustment
+%% leverage, so 1s adjustments will take roughly a day to make up the
+%% final 0.04 (twice as much leverage, but 20% of the rate).
+
+%% when drift is small or 0, let it accumulate for a bit
+catchup_time(N) when N < 0.0001 ->
+    0;
+%% when it's still relatively small, apply gentle adjustments
+catchup_time(N) when N < 0.04 ->
     1;
+%% if it's large, jam on the gas
 catchup_time(_) ->
     10.

--- a/src/miner.erl
+++ b/src/miner.erl
@@ -623,12 +623,9 @@ set_next_block_timer(State=#state{blockchain=Chain}) ->
     BlockTimeDeviation =
         case BlockTimeDeviation0 of
             N when N > 0 ->
-                min(ceil(N * N), 15);
+                catchup_time(N);
             N ->
-                %% to maintain sensitivity, and actually cap slowdown,
-                %% invert all the operations here, and use abs to
-                %% preserve sign.
-                max(floor(N * abs(N)), -15)
+                -1 * catchup_time(N)
         end,
     NextBlockTime = max(0, (LastBlockTimestamp + BlockTime + BlockTimeDeviation) - Now),
     lager:info("Next block after ~p is in ~p seconds", [LastBlockTimestamp, NextBlockTime]),
@@ -652,3 +649,8 @@ process_bbas(N, BBAs) ->
                     <<>>
             end
     end.
+
+catchup_time(N) when N < 0.15 ->
+    1;
+catchup_time(_) ->
+    10.


### PR DESCRIPTION
While the current system draws neat curves, there's no inherent momentum to the system.  As such, we should move to a system that catches up at maximum speed until the final trim adjustments, which are made a minimum speed to prevent large time oscillations around the target time.