### PR TITLE
Handle GWMP (Semtech UDP protocol) V2 messages

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -494,7 +494,7 @@ maybe_send_udp_ack(Socket, IP, Port, Packet, _RegDomainConfirmed)->
 sort_packets(Packets) ->
     lists:sort(
         fun(A, B) ->
-            maps:get(<<"lsnr">>, A) >= maps:get(<<"lsnr">>, B)
+            packet_snr(A) >= packet_snr(B)
         end,
         Packets
     ).
@@ -514,8 +514,8 @@ handle_packets([Packet|Tail], Gateway, #state{reg_region = Region} = State) ->
             %% onion server
             miner_onion_server:decrypt_radio(
                 Payload,
-                erlang:trunc(maps:get(<<"rssi">>, Packet)),
-                maps:get(<<"lsnr">>, Packet),
+                erlang:trunc(packet_rssi(Packet)),
+                packet_snr(Packet),
                 %% TODO we might want to send GPS time here, if available
                 maps:get(<<"tmst">>, Packet),
                 Freq,
@@ -578,8 +578,8 @@ maybe_mirror({Sock, Destination}, Packet) ->
 -spec send_to_router(lorawan, blockchain_helium_packet:routing_info(), map(), atom()) -> ok.
 send_to_router(Type, RoutingInfo, Packet, Region) ->
     Data = base64:decode(maps:get(<<"data">>, Packet)),
-    RSSI = maps:get(<<"rssi">>, Packet),
-    SNR = maps:get(<<"lsnr">>, Packet),
+    RSSI = packet_rssi(Packet),
+    SNR = packet_snr(Packet),
     %% TODO we might want to send GPS time here, if available
     Time = maps:get(<<"tmst">>, Packet),
     Freq = maps:get(<<"freq">>, Packet),
@@ -651,4 +651,46 @@ channel(Freq, [H|T], Acc) ->
             Acc;
         false ->
             channel(Freq, T, Acc+1)
+    end.
+
+%% Extracts a packet's RSSI, abstracting away the differences between
+%% GWMP JSON V1/V2.
+-spec packet_rssi(map()) -> number().
+packet_rssi(Packet) ->
+    case maps:get(<<"rssi">>, Packet, undefined) of
+        %% GWMP V2
+        undefined ->
+            %% `rsig` is a list. It can contain more than one signal
+            %% quality object if the packet was received on multiple
+            %% antennas/receivers. So let's pick the one with the
+            %% highest RSSI[Channel]
+            [H|T] = maps:get(<<"rsig">>, Packet),
+            Selector = fun(Obj, Best) ->
+                               erlang:max(Best, maps:get(<<"rssic">>, Obj))
+                       end,
+            lists:foldl(Selector, maps:get(<<"rssic">>, H), T);
+        %% GWMP V1
+        RSSI ->
+            RSSI
+    end.
+
+%% Extracts a packet's SNR, abstracting away the differences between
+%% GWMP JSON V1/V2.
+-spec packet_snr(map()) -> number().
+packet_snr(Packet) ->
+    case maps:get(<<"lsnr">>, Packet, undefined) of
+        %% GWMP V2
+        undefined ->
+            %% `rsig` is a list. It can contain more than one signal
+            %% quality object if the packet was received on multiple
+            %% antennas/receivers. So let's pick the one with the
+            %% highest SNR
+            [H|T] = maps:get(<<"rsig">>, Packet),
+            Selector = fun(Obj, Best) ->
+                               erlang:max(Best, maps:get(<<"lsnr">>, Obj))
+                       end,
+            lists:foldl(Selector, maps:get(<<"lsnr">>, H), T);
+        %% GWMP V1
+        LSNR ->
+            LSNR
     end.


### PR DESCRIPTION
GWMP V2 moves `rssi` and `lsnr` to new subobject named `rsig`.  This PR replaces `map:get` for those two fields with accessors.

### `rsig` object
   Name |  Type  | Function
:------:|:------:|--------------------------------------------------------------
ant     | number | Antenna number on which signal has been received
chan    | number | (unsigned integer) Concentrator "IF" channel used for RX
rssic   | number | (signed integer) RSSI in dBm of the channel (1 dB precision)
rssis   | number | (signed integer) RSSI in dBm of the signal (1 dB precision)
rssisd  | number | (unsigned integer) Standard deviation of RSSI during preamble
lsnr    | number | (signed float) Lora SNR ratio in dB (0.1 dB precision)
etime   | string | Encrypted 'main' fine timestamp, ns precision [0..999999999]
foff    | number | Frequency offset in Hz [-125 kHz..+125 khz]
ftstat  | number | (8 bits unsigned integer) Fine timestamp status
ftver   | number | Version of the 'main' fine timestamp
ftdelta | number | Number of nanoseconds between the 'main' fts and the 'alternative' one

[ch8886]