### PR TITLE
Bump blessed snapshot

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 522721},
+   {blessed_snapshot_block_height, 535681},
    {blessed_snapshot_block_hash,
-    <<215,186,116,71,190,84,7,3,170,111,67,4,204,150,178,145,222,24,37,29,209,58,81,246,97,210,23,200,80,248,249,243>>},
+    <<78,48,67,4,49,161,46,53,135,40,254,219,250,62,224,61,252,95,27,134,93,96,89,83,54,231,26,124,214,197,101,246>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
bump snapshot to `535681`

```Height 535681
Hash <<78,48,67,4,49,161,46,53,135,40,254,219,250,62,224,61,252,95,27,134,93,
       96,89,83,54,231,26,124,214,197,101,246>>
Have false
```