### PR TITLE
Make election_done asynchronous to avoid mutual blocking consensus mgr

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"ce3239c3463cf734dd7c60a0f6319d44d1e2a7f7"}},
+       {ref,"bed541ea3d01e0ee38627d51a268545f361dc581"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
Instead of doing a gen_server:call and blocking on the reply, do a
gen_server cast and wait for a `mark_done` event to come back so we know
we've handed the key off. To make this work without sending duplicate
election_done messages to the consensus manager we track whether the
election done was acknowleded with a seperate record field.

This PR also attempts to improve the logging slightly to include
election delay adjacent to the election height more consistently and it
also tries to improve the group cancel behaviour.