### PR TITLE
Update blockchain-core and bump snap

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 549361},
+   {blessed_snapshot_block_height, 555121},
    {blessed_snapshot_block_hash,
-    <<150,249,162,11,230,105,19,124,149,147,39,189,179,38,115,131,155,27,43,231,44,130,165,154,183,118,59,93,170,105,238,106>>},
+    <<5,98,107,54,176,67,254,172,144,204,163,3,210,16,38,245,223,88,236,19,229,129,67,171,84,0,132,61,122,60,164,82>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"6249f7b5d8502580a05c02ff9b323651e2e9f793"}},
+       {ref,"711e5b3d5170ecf774ed4596de4b3bbc316e3303"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
```Height 555121
Hash <<5,98,107,54,176,67,254,172,144,204,163,3,210,16,38,245,223,88,236,19,
       229,129,67,171,84,0,132,61,122,60,164,82>>
Have true
```