### PR TITLE
Fix argument order in calls to retry_with_rx2

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -426,14 +426,14 @@ handle_udp_packet(<<?PROTOCOL_2:8/integer-unsigned,
                     case blockchain_helium_packet_v1:rx2_window(HlmPacket) of
                         undefined -> lager:warning("No RX2 available"),
                                      {error, too_late};
-                        _ -> retry_with_rx2(From, HlmPacket, State1)
+                        _ -> retry_with_rx2(HlmPacket, From, State1)
                     end;
                 <<"TOO_EARLY">> ->
                     lager:info("too early"),
                     case blockchain_helium_packet_v1:rx2_window(HlmPacket) of
                         undefined -> lager:warning("No RX2 available"),
                                      {error, too_early};
-                        _ -> retry_with_rx2(From, HlmPacket, State1)
+                        _ -> retry_with_rx2(HlmPacket, From, State1)
                     end;
                 <<"TX_FREQ">> ->
                     lager:info("tx frequency not supported"),


### PR DESCRIPTION
In addition to the fixes in calls to `retry_with_rx2`, this PR first adds type specs to to ensure those calls are flagged. The second commit is the actual argument order fix.

## Testing

This bug only rears its head when dowlinking @ RX1 fails. You can apply the following patch to ensure that happens.

```patch
diff --git a/src/miner_lora.erl b/src/miner_lora.erl
index 23d1a37..efeda79 100644
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -770,7 +770,9 @@ send_packet(Payload, When, ChannelSelectorFun, DataRate, Power, IPol, HlmPacket,
             end,

             Token = mk_token(Timers),
-            Packet = create_packet(Payload, When, LocalFreq, DataRate, Power, IPol, Token),
+            NewWhen = When - 5000000,
+            lager:warning("Adjusting When from ~p down to ~p", [When, NewWhen]),
+            Packet = create_packet(Payload, NewWhen, LocalFreq, DataRate, Power, IPol, Token),
             maybe_mirror(State#state.mirror_socket, Packet),
             lager:debug("sending packet via channel: ~p",[LocalFreq]),
             ok = gen_udp:send(Socket, IP, Port, Packet),
@@ -822,4 +824,6 @@ retry_with_rx2(HlmPacket0, From, State) ->
     Payload = blockchain_helium_packet_v1:payload(HlmPacket0),
     ChannelSelectorFun = fun(_FreqList) -> Freq end,
     HlmPacket1 = HlmPacket0#packet_pb{rx2_window=undefined},
-    send_packet(Payload, TS, ChannelSelectorFun, DataRate, Power, true, HlmPacket1, From, State).
+    NewTS = TS + 5000000,
+    lager:warning("Adjusting TS from ~p up to ~p", [TS, NewTS]),
+    send_packet(Payload, NewTS, ChannelSelectorFun, DataRate, Power, true, HlmPacket1, From, State).
```