### PR TITLE
Update blockchain-core and snapshot to 560881

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 555121},
+   {blessed_snapshot_block_height, 560881},
    {blessed_snapshot_block_hash,
-    <<5,98,107,54,176,67,254,172,144,204,163,3,210,16,38,245,223,88,236,19,229,129,67,171,84,0,132,61,122,60,164,82>>},
+    <<69,17,78,79,33,60,213,229,142,128,199,64,90,53,181,248,164,254,58,151,144,219,186,45,113,138,183,54,140,247,130,123>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"711e5b3d5170ecf774ed4596de4b3bbc316e3303"}},
+       {ref,"317cc36b2c1c0742a7401a7598f58c313542f1b4"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
```Height 560881
Hash <<69,17,78,79,33,60,213,229,142,128,199,64,90,53,181,248,164,254,58,151,
       144,219,186,45,113,138,183,54,140,247,130,123>>
Have true
```