### PR TITLE
Make the "gentle nudge" period smaller

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -668,7 +668,7 @@ process_bbas(N, BBAs) ->
 catchup_time(N) when N < 0.0001 ->
     0;
 %% when it's still relatively small, apply gentle adjustments
-catchup_time(N) when N < 0.04 ->
+catchup_time(N) when N < 0.01 ->
     1;
 %% if it's large, jam on the gas
 catchup_time(_) ->


### PR DESCRIPTION
With the current block time adjustment code, we never seem to get down to 60 second blocks.  This should make us get closer before we move to slow adjustments, which should let us average closer to 60s blocks.