### PR TITLE
update snap now that they're working again

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 624961},
+   {blessed_snapshot_block_height, 635041},
    {blessed_snapshot_block_hash,
-    <<56,11,178,87,0,236,135,94,57,4,140,249,152,227,154,54,211,221,30,112,41,48,105,70,16,142,244,107,27,44,176,199>>},
+    <<96,219,0,124,74,42,18,57,192,230,208,144,29,208,88,237,148,56,219,179,209,21,68,39,13,251,6,134,49,85,15,63>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
we've verified that snapshots are now working after the deployment of `2020.12.15.2`, and now we'll bump the snapshot to a working and recent one.