### PR TITLE
Bump snap to 642961 and update core

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 635041},
+   {blessed_snapshot_block_height, 642961},
    {blessed_snapshot_block_hash,
-    <<96,219,0,124,74,42,18,57,192,230,208,144,29,208,88,237,148,56,219,179,209,21,68,39,13,251,6,134,49,85,15,63>>},
+    <<<213,216,64,169,119,157,209,112,77,143,249,60,59,237,142,170,255,100,183,105,232,58,104,10,134,30,63,135,140,222,211,65>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"b2e1468f1a50083e0de94dfc4052bb22dd2386c8"}},
+       {ref,"91fd3b7b4a227abd88145a55a323377d83d6431c"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
```
Height 642961
Hash <<213,216,64,169,119,157,209,112,77,143,249,60,59,237,142,170,255,100,183,
       105,232,58,104,10,134,30,63,135,140,222,211,65>>
Have true
```

Also updates core for [invalid witness reason](https://github.com/helium/blockchain-core/pull/706) support.