### PR TITLE
Adjust the POC challenge jitter factor

### DIFF
--- a/src/poc/miner_poc_statem.erl
+++ b/src/poc/miner_poc_statem.erl
@@ -650,10 +650,10 @@ allow_request(BlockHash, #data{blockchain=Blockchain,
                     case blockchain_ledger_gateway_v2:last_poc_challenge(GwInfo) of
                         undefined ->
                             lager:info("got block ~p @ height ~p (never challenged before)", [BlockHash, Height]),
-                    true;
+                            true;
                         LastChallenge ->
                             case (Height - LastChallenge) > POCInterval of
-                                true -> 1 == rand:uniform(trunc(POCInterval / 4));
+                                true -> 1 == rand:uniform(max(10, POCInterval div 10));
                                 false -> false
                             end
                     end,


### PR DESCRIPTION
Problem to solve: The current POC challenge interval only has about a 1-in-60 chance of triggering. This is too infrequent. Ideally challenges would scale against some kind of global setting, but that is future work.

Solution: Modify the jitter factor to make it easier to trigger challenges more frequently.