### PR TITLE
Bump snapshot to 653041

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 642961},
+   {blessed_snapshot_block_height, 653041},
    {blessed_snapshot_block_hash,
-    <<213,216,64,169,119,157,209,112,77,143,249,60,59,237,142,170,255,100,183,105,232,58,104,10,134,30,63,135,140,222,211,65>>},
+    <<157,193,26,18,133,11,28,6,94,75,124,63,106,13,247,88,191,177,55,183,136,225,21,167,52,218,223,255,61,103,114,73>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
./_build/dev/rel/miner/bin/miner snapshot list
Height 653041
Hash <<157,193,26,18,133,11,28,6,94,75,124,63,106,13,247,88,191,177,55,183,136,
       225,21,167,52,218,223,255,61,103,114,73>>
Have true

```