### PR TITLE
Update snapshot to 687601 and bump core

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,9 +35,9 @@
   [
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 672481},
+   {blessed_snapshot_block_height, 687601},
    {blessed_snapshot_block_hash,
-    <<237,177,164,220,89,1,30,143,194,184,161,73,218,218,217,69,74,45,41,116,6,179,68,75,129,34,78,200,232,248,86,91>>},
+    <<173,73,1,68,101,239,196,239,97,83,103,83,198,202,118,204,45,156,184,237,8,250,185,40,137,69,28,17,139,190,163,107>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"3f406dd209fe37a1bc1b3983057d6f4b7adb297a"}},
+       {ref,"6d36d1bb6a0cd60a6668b498920b1598aa981977"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",


### PR DESCRIPTION
~~TODO: Update core sha once https://github.com/helium/blockchain-core/pull/721 lands~~