### PR TITLE
Useablity improvments to miner info commands

### DIFF
--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -55,12 +55,13 @@ register_all_cmds() ->
 info_usage() ->
     [["info"],
      ["miner info commands\n\n",
-      "  info height - Get height of the blockchain for this miner.\n",
-      "  info in_consensus - Show if this miner is in the consensus_group.\n"
-      "  name - Shows the name of this miner.\n"
-      "  block_age - Get age of the latest block in the chain, in seconds.\n"
-      "  p2p_status - Shows key peer connectivity status of this miner.\n"
-      "  summary - Get a collection of key data points for this miner.\n"
+      "  info height            - Get height of the blockchain for this miner.\n",
+      "  info in_consensus      - Show if this miner is in the consensus_group.\n"
+      "  info name              - Shows the name of this miner.\n"
+      "  info block_age         - Get age of the latest block in the chain, in seconds.\n"
+      "  info p2p_status        - Shows key peer connectivity status of this miner.\n"
+      "  info summary           - Get a collection of key data points for this miner.\n"
+      "  info region            - Get the operatating region for this miner.\n"
      ]
     ].
 
@@ -123,7 +124,7 @@ info_in_consensus_cmd() ->
 info_in_consensus_usage() ->
     [["info", "in_consensus"],
      ["info in_consensus \n\n",
-      "  Get whether this miner is in the consensus group.\n\n"
+      "  Get whether this miner is currently in the consensus group.\n\n"
      ]
     ].
 
@@ -144,7 +145,7 @@ info_name_cmd() ->
 info_name_usage() ->
     [["info", "name"],
      ["info name \n\n",
-      "  Get name for this miner.\n\n"
+      "  Get animal name for this miner.\n\n"
      ]
     ].
 


### PR DESCRIPTION
There was missing "info" in the display. Made it look like the other commands such as peer.
Also made it more clear for what info_in_consensus_usage(), and info_name_usage() does.
Added the region to the info_usage(). Was missing in the past.

These are all just small changes, no changes to the base codebase, only to the UI of the CLI interface for the miners.