### PR TITLE
Update packet_rssi function to use RSSIS if available

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -694,7 +694,8 @@ tmst_to_local_monotonic_time(Tmst_us, PrevTmst_us, PrevMonoTime_us) ->
 %% GWMP JSON V1/V2.
 -spec packet_rssi(map()) -> number().
 packet_rssi(Packet) ->
-    case maps:get(<<"rssi">>, Packet, undefined) of
+    %% SX1302 uses RSSIS and SX1301 uses RSSI
+    case maps:get(<<"rssis">>, Packet, maps:get(<<"rssi">>, Packet, undefined)) of
         %% GWMP V2
         undefined ->
             %% `rsig` is a list. It can contain more than one signal


### PR DESCRIPTION
SX1302's use the `rssis` field from the packet forwarder to denote the strength of the signal, versus `rssi` which is the strength of the *channel*. SX1302 `rssis` appears to be behave like SX1301 `rssi`, so this update uses `rssis` if available.