### PR TITLE
Update packet_rssi function to use RSSIS from GWMP JSON v2

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -704,9 +704,9 @@ packet_rssi(Packet) ->
             %% highest RSSI[Channel]
             [H|T] = maps:get(<<"rsig">>, Packet),
             Selector = fun(Obj, Best) ->
-                               erlang:max(Best, maps:get(<<"rssic">>, Obj))
+                               erlang:max(Best, maps:get(<<"rssis">>, Obj))
                        end,
-            lists:foldl(Selector, maps:get(<<"rssic">>, H), T);
+            lists:foldl(Selector, maps:get(<<"rssis">>, H), T);
         %% GWMP V1
         RSSI ->
             RSSI


### PR DESCRIPTION
Since #624 emphasizes using RSSIS whenever available, we should be doing it for GWMP JSON v2 as well.