### PR TITLE
Pevm/validators

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -212,7 +212,7 @@
              [
               {relx, 
                [
-                {release, {miner, {semver, "val"}},
+                {release, {miner, "0.10"},
                  [miner,
                   observer,
                   tools,

--- a/rebar.config
+++ b/rebar.config
@@ -212,7 +212,7 @@
              [
               {relx, 
                [
-                {release, {miner, "0.10"},
+                {release, {miner, "0.1.0"},
                  [miner,
                   observer,
                   tools,


### PR DESCRIPTION
Build is not happy with {semver, "val"}

throwing this:
Resolved miner-al: No names found, cannot describe anything.+build.fatal:Invalidobjectname'fatal'..

changed to same syntax as prod.