### PR TITLE
Revert "Update packet_rssi function to use RSSIS if available"

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -694,8 +694,7 @@ tmst_to_local_monotonic_time(Tmst_us, PrevTmst_us, PrevMonoTime_us) ->
 %% GWMP JSON V1/V2.
 -spec packet_rssi(map()) -> number().
 packet_rssi(Packet) ->
-    %% SX1302 uses RSSIS and SX1301 uses RSSI
-    case maps:get(<<"rssis">>, Packet, maps:get(<<"rssi">>, Packet, undefined)) of
+    case maps:get(<<"rssi">>, Packet, undefined) of
         %% GWMP V2
         undefined ->
             %% `rsig` is a list. It can contain more than one signal


### PR DESCRIPTION
Reverts helium/miner#624

This probably need re-characterized acceptance curves to happen first.