### PR TITLE
fix validator profile in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -225,20 +225,22 @@
                             {system_libs, false},
                             {include_erts, false}]}]
             },
-            {validator,
-             [
-              {relx, 
-               [
+            {validator, [
+              {relx, [
                 {release, {miner, {semver, "val"}},
-                 [miner,
-                  observer,
-                  tools,
-                  runtime_tools,
-                  recon]},
+                  [miner,
+                    observer,
+                    tools,
+                    runtime_tools,
+                    recon]},
                 {sys_config, "./config/val.config"},
-                      {dev_mode, false},
-                {include_src, false}]}]
-            },
+                {overlay,
+                  [{copy, "config/sys.config", "config/sys.config"}]},
+                {dev_mode, false},
+                {include_src, false},
+                {system_libs, false},
+                {include_erts, false}]}]
+            },            
             {test,
              [
               {overrides, [{add, blockchain, [{erl_opts, [{d, 'TEST'}]}]}]},


### PR DESCRIPTION
This updates the validator profile in rebar.config to create the usual folder structure with the config files. Same structure as the docker profile, but using val.config instead of docker.config.