### PR TITLE
For docker val, move log files to the data dir

### DIFF
--- a/config/docker-val.config
+++ b/config/docker-val.config
@@ -3,7 +3,7 @@
  "config/sys.config",
  {lager,
   [
-   {log_root, "/var/log/"},
+   {log_root, "/var/data/log"}
    {handlers,
     [
      {lager_file_backend, [{file, "console.log"}, {size, 52428800}, {level, info}]},


### PR DESCRIPTION
The miner docker release has the log files in the mapped data dir, which makes tailing and dealing with them slightly more convenient. this is just a change to do the same for the validator docker release.

fixes #666