### PR TITLE
WIP to clean up if init_per_testcase fails

### DIFF
--- a/test/miner_blockchain_SUITE.erl
+++ b/test/miner_blockchain_SUITE.erl
@@ -42,6 +42,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, TestCase, Config0),
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
 
@@ -130,7 +131,12 @@ init_per_testcase(TestCase, Config0) ->
     [   {master_key, {Priv, Pub}},
         {consensus_miners, ConsensusMiners},
         {non_consensus_miners, NonConsensusMiners}
-        | Config].
+        | Config]
+    catch
+        What:Why ->
+            end_per_testcase(TestCase, Config),
+            erlang:What(Why)
+    end.
 
 end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).

--- a/test/miner_packet_routing_SUITE.erl
+++ b/test/miner_packet_routing_SUITE.erl
@@ -23,6 +23,7 @@ all() ->
 
 init_per_testcase(TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, TestCase, Config0),
+    try
     Addresses = ?config(addresses, Config),
     N = ?config(num_consensus_members, Config),
     Curve = ?config(dkg_curve, Config),
@@ -50,7 +51,12 @@ init_per_testcase(TestCase, Config0) ->
     timer:sleep(5000),
     ok = miner_ct_utils:load_genesis_block(GenesisBlock, Miners, Config),
     miner_fake_radio_backplane ! go,
-    Config.
+    Config
+    catch
+        What:Why ->
+            end_per_testcase(TestCase, Config),
+            erlang:What(Why)
+    end.
 
 end_per_testcase(TestCase, Config) ->
     gen_server:stop(miner_fake_radio_backplane),

--- a/test/miner_payment_txn_SUITE.erl
+++ b/test/miner_payment_txn_SUITE.erl
@@ -38,6 +38,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
     InitialPaymentTransactions = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
@@ -74,7 +75,12 @@ init_per_testcase(_TestCase, Config0) ->
 
     [   {consensus_miners, ConsensusMiners},
         {non_consensus_miners, NonConsensusMiners}
-        | Config].
+        | Config]
+    catch
+        What:Why ->
+            end_per_testcase(_TestCase, Config),
+            erlang:What(Why)
+    end.
 
 
 end_per_testcase(_TestCase, Config) ->

--- a/test/miner_payment_v2_txn_SUITE.erl
+++ b/test/miner_payment_v2_txn_SUITE.erl
@@ -34,6 +34,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
     InitialPaymentTransactions = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
@@ -70,8 +71,12 @@ init_per_testcase(_TestCase, Config0) ->
 
     [   {consensus_miners, ConsensusMiners},
         {non_consensus_miners, NonConsensusMiners}
-        | Config].
-
+        | Config]
+    catch
+        What:Why ->
+            end_per_testcase(_TestCase, Config),
+            erlang:What(Why)
+    end.
 
 end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).

--- a/test/miner_reward_SUITE.erl
+++ b/test/miner_reward_SUITE.erl
@@ -32,6 +32,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
     InitialCoinbaseTxns = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
@@ -74,7 +75,13 @@ init_per_testcase(_TestCase, Config0) ->
     ok = miner_ct_utils:wait_for_gte(height, Miners, 2),
 
     [   {consensus_miners, ConsensusMiners},
-        {non_consensus_miners, NonConsensusMiners} | Config].
+        {non_consensus_miners, NonConsensusMiners} | Config]
+    catch
+        What:Why ->
+            end_per_testcase(_TestCase, Config),
+            erlang:What(Why)
+    end.
+
 
 end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).

--- a/test/miner_state_channel_SUITE.erl
+++ b/test/miner_state_channel_SUITE.erl
@@ -110,6 +110,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, TestCase, Config0),
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
     NumConsensusMembers = ?config(num_consensus_members, Config),
@@ -215,7 +216,13 @@ init_per_testcase(TestCase, Config0) ->
      {router_node, {RouterNode, RouterPubkeyBin, RouterSigFun}},
      {non_consensus_miners, NonConsensusMiners},
      {default_routers, application:get_env(miner, default_routers, [])}
-     | Config].
+     | Config]
+    catch
+        What:Why ->
+            end_per_testcase(TestCase, Config),
+            erlang:What(Why)
+    end.
+
 
 end_per_testcase(TestCase, Config) ->
     ok = block_listener:stop(),

--- a/test/miner_transfer_hotspot_txn_SUITE.erl
+++ b/test/miner_transfer_hotspot_txn_SUITE.erl
@@ -38,6 +38,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    try
     [Seller | _ ] = Miners = ?config(miners, Config),
     SellerAddr = ct_rpc:call(Seller, blockchain_swarm, pubkey_bin, []),
     Addresses = ?config(addresses, Config),
@@ -77,7 +78,12 @@ init_per_testcase(_TestCase, Config0) ->
 
     [   {consensus_miners, ConsensusMiners},
         {non_consensus_miners, NonConsensusMiners}
-        | Config].
+        | Config]
+    catch
+        What:Why ->
+            end_per_testcase(_TestCase, Config),
+            erlang:What(Why)
+    end.
 
 
 end_per_testcase(_TestCase, Config) ->

--- a/test/miner_txn_bundle_SUITE.erl
+++ b/test/miner_txn_bundle_SUITE.erl
@@ -54,6 +54,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
     Balance = 5000,
@@ -90,7 +91,12 @@ init_per_testcase(_TestCase, Config0) ->
     [
         {consensus_miners, ConsensusMiners},
         {non_consensus_miners, NonConsensusMiners}
-        | NewConfig].
+        | NewConfig]
+    catch
+        What:Why ->
+            end_per_testcase(_TestCase, Config),
+            erlang:What(Why)
+    end.
 
 end_per_testcase(_TestCase, Config) ->
     miner_ct_utils:end_per_testcase(_TestCase, Config).

--- a/test/miner_txn_mgr_SUITE.erl
+++ b/test/miner_txn_mgr_SUITE.erl
@@ -39,7 +39,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_TestCase, Config0) ->
     Config = miner_ct_utils:init_per_testcase(?MODULE, _TestCase, Config0),
-
+    try
     Miners = ?config(miners, Config),
     Addresses = ?config(addresses, Config),
     InitialPaymentTransactions = [ blockchain_txn_coinbase_v1:new(Addr, 5000) || Addr <- Addresses],
@@ -74,7 +74,12 @@ init_per_testcase(_TestCase, Config0) ->
 
     [   {consensus_miners, ConsensusMiners},
         {non_consensus_miners, NonConsensusMiners}
-        | Config].
+        | Config]
+    catch
+        What:Why ->
+            end_per_testcase(_TestCase, Config),
+            erlang:What(Why)
+    end.
 
 
 end_per_testcase(_TestCase, Config) ->


### PR DESCRIPTION
This needs more work, but it appears to help if we crash while initting the testcase (end per testcase is not called, so the nodes are not stopped).