### PR TITLE
Bump rocksdb buffers

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -75,7 +75,7 @@
      {arena_block_size, 262144}, % 256kB
      {write_buffer_size, 262144}, % 256kB
      {db_write_buffer_size, 8388608}, % 8MB
-     {max_write_buffer_number, 8},
+     {max_write_buffer_number, 10},
      {keep_log_file_num, 5}
     ]}
   ]},


### PR DESCRIPTION
This PR is an attempt to reduce the frequency of errors that https://github.com/helium/relcast/pull/42 attempts to handle. Increasing [`max_write_buffer_number`] has the effect of increasing `max_write_buffer_size_to_maintain`:

```c++
  // Default:
  // If using a TransactionDB/OptimisticTransactionDB, the default value will
  // be set to the value of 'max_write_buffer_number * write_buffer_size'
  // if it is not explicitly set by the user.  Otherwise, the default is 0.
  int64_t max_write_buffer_size_to_maintain = 0;
```

I believe this PR is low-risk, and I'm purposely conservatively bumping the value by quantity 2 instead of going to the next power of two. However, fine tuning these values require in depth knowledge and profiling of an application's RocksDB usage.

[`max_write_buffer_number`]: https://github.com/facebook/rocksdb/blob/master/include/rocksdb/advanced_options.h#L253-L257