### PR TITLE
Bump longfi to 0.2.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
         {ebus, {git, "https://github.com/helium/ebus.git", {branch, "master"}}},
         {jsx, {git, "https://github.com/talentdeficit/jsx.git", {branch, "v2.8.0"}}},
         {kvc, {git, "https://github.com/etrepum/kvc", {tag, "v1.7.0"}}},
-        {longfi, {git, "https://github.com/helium/longfi-erlang", {branch, "jsk/complete-api"}}},
+        {longfi, {git, "https://github.com/helium/longfi-erlang", {tag, "0.2.0"}}},
         recon
        ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -105,7 +105,7 @@
  {<<"libp2p_crypto">>,{pkg,<<"libp2p_crypto">>,<<"1.3.2">>},2},
  {<<"longfi">>,
   {git,"https://github.com/helium/longfi-erlang",
-       {ref,"b346ff24493ebe04da8a12cee318ea8f9b9c7f3c"}},
+       {ref,"af47a584ebfe695d968bc46592b8145679288a8d"}},
   0},
  {<<"merkerl">>,
   {git,"https://github.com/helium/merkerl.git",


### PR DESCRIPTION
We've been pulling in a branch of longfi for a long time which just got merged. This new tag tag also adds a commit by @ke6jjj that fixes BSD builds.