### PR TITLE
frequency: update Uganda to correct frequency

### DIFF
--- a/priv/countries_reg_domains.csv
+++ b/priv/countries_reg_domains.csv
@@ -227,7 +227,7 @@ TC,21.694025,-71.797928,Turks and Caicos Islands,AU915,zone2
 TV,-7.109535,177.64933,Tuvalu,,zone3
 UM,,,U.S. Minor Outlying Islands,US915,zone2
 VI,18.335765,-64.896335,U.S. Virgin Islands,US915,zone2
-UG,1.373333,32.290275,Uganda,EU868,zone1
+UG,1.373333,32.290275,Uganda,IN865,zone1
 UA,48.379433,31.16558,Ukraine,EU868,zone1
 AE,23.424076,53.847818,United Arab Emirates,EU868,zone1
 GB,55.378051,-3.435973,United Kingdom,EU868,zone1


### PR DESCRIPTION
Accidentally put EU868 for Uganda instead of IN865 as per the lora doc

Closes: #677 
Change-type: patch
Signed-off-by: Aaron Shaw <shawaj@gmail.com>