### PR TITLE
Use arm64 build queues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,7 +66,7 @@ steps:
       IMAGE_FORMAT: "docker"
       IMAGE_ARCH: "arm64"
     agents:
-      queue: "erlang"
+      queue: "arm64"
     commands:
       - "git fetch -t"
       - ".buildkite/scripts/make_val_image.sh"
@@ -74,7 +74,7 @@ steps:
   - if: build.tag =~ /\_GA$$/
     name: ":whale: ARM64 docker"
     agents:
-      queue: "erlang"
+      queue: "arm64"
     env:
       REGISTRY_HOST: "quay.io"
       REGISTRY_NAME: "miner"


### PR DESCRIPTION
Problem to solve: Currently ARM64 docker images build with CPU emulation using QEMU which is very slow

Solution: Use a native ARM64 server to build these images