### PR TITLE
Allow configuring ECC I2C bus & address

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -42,7 +42,7 @@
    {blessed_snapshot_block_hash,
      <<209,92,211,142,85,214,202,92,230,55,117,141,196,113,173,198,47,210,64,105,147,50,31,203,154,41,251,234,202,170,123,103>>},
    {port, 44158},
-   {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
+   {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}, {bus, "i2c-1"}, {address, 16#60}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},

--- a/rebar.lock
+++ b/rebar.lock
@@ -28,7 +28,7 @@
   0},
  {<<"ecc508">>,
   {git,"https://github.com/helium/ecc508.git",
-       {ref,"c089c1591a6a0bc9a393e1cefceadb0b19ee8c59"}},
+       {ref,"762d985c759b988d6db7db4e2701649d50ccc7f4"}},
   0},
  {<<"ecc_compact">>,{pkg,<<"ecc_compact">>,<<"1.0.5">>},3},
  {<<"enacl">>,{pkg,<<"enacl">>,<<"1.1.1">>},3},

--- a/src/miner_ecc_worker.erl
+++ b/src/miner_ecc_worker.erl
@@ -5,7 +5,7 @@
          ecdh/1,
          get_pid/0]).
 
--export([start_link/1,
+-export([start_link/3,
          init/1,
          handle_call/3,
          handle_cast/2,
@@ -35,12 +35,12 @@ ecdh({ecc_compact, PubKey}) ->
 get_pid() ->
     gen_server:call(?MODULE, get_pid).
 
-start_link(KeySlot) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [KeySlot], []).
+start_link(KeySlot, Bus, Address) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [KeySlot, Bus, Address], []).
 
 
-init([KeySlot]) ->
-    {ok, ECCHandle} = ecc508:start_link(),
+init([KeySlot, Bus, Address]) ->
+    {ok, ECCHandle} = ecc508:start_link(Bus, Address),
     {ok, #state{ecc_handle=ECCHandle, key_slot=KeySlot}}.
 
 

--- a/src/miner_keys.erl
+++ b/src/miner_keys.erl
@@ -71,11 +71,13 @@ keys({file, BaseDir}) ->
 keys({ecc, Props}) when is_list(Props) ->
     KeySlot0 = proplists:get_value(key_slot, Props, 0),
     OnboardingKeySlot = proplists:get_value(onboarding_key_slot, Props, 15),
+    Bus = proplists:get_value(bus, Props, "i2c-1"),
+    Address = proplists:get_value(address, Props, 16#60),
     {ok, ECCPid} = case whereis(miner_ecc_worker) of
                        undefined ->
                            %% Create a temporary ecc link to get the public key and
                            %% onboarding keys for the given slots as well as the
-                           ecc508:start_link();
+                           ecc508:start_link(Bus, Address);
                        _ECCWorker ->
                            %% use the existing ECC pid
                            miner_ecc_worker:get_pid()
@@ -101,6 +103,8 @@ keys({ecc, Props}) when is_list(Props) ->
 
     #{ pubkey => PubKey,
        key_slot => KeySlot,
+       bus => Bus,
+       address => Address,
        %% The signing and ecdh functions will use an actual
        %% worker against a named process.
        ecdh_fun => fun(PublicKey) ->

--- a/src/miner_sup.erl
+++ b/src/miner_sup.erl
@@ -58,10 +58,12 @@ init(_Args) ->
         {ecc, Props} when is_list(Props) ->
             #{ pubkey := PublicKey,
                key_slot := KeySlot,
+               bus := Bus,
+               address := Address,
                ecdh_fun := ECDHFun,
                sig_fun := SigFun
              } = miner_keys:keys({ecc, Props}),
-            ECCWorker = [?WORKER(miner_ecc_worker, [KeySlot])];
+            ECCWorker = [?WORKER(miner_ecc_worker, [KeySlot, Bus, Address])];
         {PublicKey, ECDHFun, SigFun} ->
             ECCWorker = [],
             ok


### PR DESCRIPTION
This PR adds two new options to the ECC section of the configuration file:

 * `bus` allows configuring the I2C bus and defaults to `i2c-1`
 * `address` allows configuring the I2C address and defaults to `0x60`

:warning: This PR depends on https://github.com/helium/ecc508/pull/9 ~and does not (yet) update the `rebar.lock` accordingly.~