### PR TITLE
regenerate roaming router swarm_key

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -30,7 +30,7 @@
      {"/p2p/112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE", "/ip4/52.8.80.146/tcp/2154"},
      {"/p2p/1124CJ9yJaHq4D6ugyPCDnSBzQik61C1BqD9VMh1vsUmjwt16HNB", "/ip4/54.176.88.149/tcp/2154"},
      {"/p2p/11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv", "/ip4/54.193.165.228/tcp/2154"},
-     {"/p2p/11kKRNVzC5BCevniHc5asGZJdHxHQPEFUsSYpdm892hrfNVRoGP", "/ip4/44.238.156.97/tcp/2154"}
+     {"/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa", "/ip4/44.238.156.97/tcp/2154"}
 
     ]}
   ]},
@@ -94,7 +94,7 @@
    {election_interval, 30},
    {radio_device, { {127,0,0,1}, 1680,
                     {127,0,0,1}, 31341} },
-   {default_routers, ["/p2p/112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE", "/p2p/11kKRNVzC5BCevniHc5asGZJdHxHQPEFUsSYpdm892hrfNVRoGP"]},
+   {default_routers, ["/p2p/112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE", "/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa"]},
    {mark_mods, [miner_hbbft_handler]},
    {stabilization_period, 50000},
    {reg_domains_file, "countries_reg_domains.csv"},


### PR DESCRIPTION
`helium-wallet` had a bug when generating swarm_keys when the previous swarm_key was being generated. This is a new swarm_key for the roaming router and has been tested.