### PR TITLE
give more time to consensus groups and less time to poc receipts

### DIFF
--- a/src/miner_hbbft_sidecar.erl
+++ b/src/miner_hbbft_sidecar.erl
@@ -19,8 +19,8 @@
 
 -define(SERVER, ?MODULE).
 
--define(SlowTxns, #{blockchain_txn_poc_receipts_v1 => 125,
-                    blockchain_txn_consensus_group_v1 => 10000}).
+-define(SlowTxns, #{blockchain_txn_poc_receipts_v1 => 100,
+                    blockchain_txn_consensus_group_v1 => 30000}).
 
 %% txns that do not appear naturally
 -define(InvalidTxns, [blockchain_txn_reward_v1, blockchain_txn_reward_v2]).


### PR DESCRIPTION
Even with the fastest hotspots, txn volume is such that we're struggling to validate good election transactions before they time out.  This adjustment will give less time to overly expensive poc receipts and much more time to elections, which should allow them to succeed more often.