### PR TITLE
add time-based skip voting

### DIFF
--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -268,7 +268,7 @@ handle_message(<<BinMsgIn/binary>>, Index, #state{hbbft = HBBFT, skip_votes = Sk
                     %% ask for some time
                     miner:reset_late_block_timer(),
                     SkipGossip = {multicast, t2b({proposed_skip, ProposedRound, CurRound})},
-                    %% skip but don't discard rounds until we get a clean round
+                    %% skip but don't discard votes until we get a clean round
                     {HBBFT1, ToSend1} =
                         case hbbft:next_round(HBBFT, ProposedRound, []) of
                             {H1, ok} ->
@@ -284,6 +284,8 @@ handle_message(<<BinMsgIn/binary>>, Index, #state{hbbft = HBBFT, skip_votes = Sk
                                 {H2, Msgs}
                         end,
                     ToSend = fixup_msgs(ToSend1 ++ ToSend2),
+                    %% we retain the skip votes here because we may not succeed and we want the
+                    %% algorithm to converge more quickly in that case
                     {(state_reset(HBBFT2, S0))#state{skip_votes = Skips1},
                      [ new_epoch , SkipGossip ] ++ ToSend};
                 {wait, Skips1} ->

--- a/src/miner.erl
+++ b/src/miner.erl
@@ -249,15 +249,7 @@ hbbft_skip() ->
     case gen_server:call(?MODULE, consensus_group, 60000) of
         undefined -> ok;
         Pid ->
-            Ref = make_ref(),
-            ok = libp2p_group_relcast:handle_input(Pid, {skip, Ref, self()}),
-            receive
-                {Ref, Result} ->
-                    miner ! block_timeout,
-                    Result
-            after timer:seconds(60) ->
-                      {error, timeout}
-            end
+            ok = libp2p_group_relcast:handle_input(Pid, maybe_skip)
     end.
 
 -spec signed_block([binary()], binary()) -> ok.

--- a/test/miner_blockchain_SUITE.erl
+++ b/test/miner_blockchain_SUITE.erl
@@ -255,6 +255,8 @@ autoskip_chain_vars_test(Config) ->
         "No node accepted the bogus chain var."
     ),
 
+    {comment, miner_ct_utils:heights(MinersAll)}.
+
 autoskip_on_timeout_test(Config) ->
     %% The idea is to reproduce the following chain stall scenario:
     %% 1. 1/2 of consensus members produce timed blocks;
@@ -295,6 +297,8 @@ autoskip_on_timeout_test(Config) ->
     ||
         Node <- MinersCGBroken
     ],
+
+    %% send some more skips at broken miner 1 so we're not all on the same round
     Node1 = hd(MinersCGBroken),
     ok = ct_rpc:call(Node1, miner, hbbft_skip, [], 300),
     ok = ct_rpc:call(Node1, miner, hbbft_skip, [], 300),

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -41,6 +41,7 @@
          start_miners/1, start_miners/2,
          height/1,
          heights/1,
+         unique_heights/1,
          consensus_members/1, consensus_members/2,
          miners_by_consensus_state/1,
          in_consensus_miners/1,
@@ -63,6 +64,13 @@
          confirm_balance/3,
          confirm_balance_both_sides/5,
          wait_for_gte/3, wait_for_gte/5,
+         wait_for_equalized_heights/1,
+         wait_for_chain_stall/1,
+         wait_for_chain_stall/2,
+         assert_chain_halted/1,
+         assert_chain_halted/3,
+         assert_chain_advanced/1,
+         assert_chain_advanced/3,
 
          submit_txn/2,
          wait_for_txn/2, wait_for_txn/3, wait_for_txn/4,
@@ -85,6 +93,108 @@ chain_var_lookup_one(Key, Node) ->
     Result = ct_rpc:call(Node, blockchain, config, [Key, Ledger], 500),
     ct:pal("Var lookup. Node:~p, Result:~p", [Node, Result]),
     Result.
+
+-spec assert_chain_advanced([node()]) -> ok.
+assert_chain_advanced(Miners) ->
+    Height = wait_for_equalized_heights(Miners),
+    ?assertMatch(
+        ok,
+        miner_ct_utils:wait_for_gte(height, Miners, Height + 1),
+        "Chain advanced."
+    ),
+    ok.
+
+assert_chain_advanced(_, _, N) when N =< 0 ->
+    ok;
+assert_chain_advanced(Miners, Interval, N) ->
+    ok = assert_chain_advanced(Miners),
+    timer:sleep(Interval),
+    assert_chain_advanced(Miners, Interval, N - 1).
+
+-spec assert_chain_halted([node()]) -> ok.
+assert_chain_halted(Miners) ->
+    assert_chain_halted(Miners, 5000, 20).
+
+-spec assert_chain_halted([node()], timeout(), pos_integer()) -> ok.
+assert_chain_halted(Miners, Interval, Retries) ->
+    _ = lists:foldl(
+        fun (_, HeightPrev) ->
+            HeightCurr = wait_for_equalized_heights(Miners),
+            ?assertEqual(HeightPrev, HeightCurr, "Chain halted."),
+            timer:sleep(Interval),
+            HeightCurr
+        end,
+        wait_for_equalized_heights(Miners),
+        lists:duplicate(Retries, {})
+    ),
+    ok.
+
+wait_for_chain_stall(Miners) ->
+    wait_for_chain_stall(Miners, #{}).
+
+-spec wait_for_chain_stall([node()], Options) -> ok | error when
+    Options :: #{
+        interval      => timeout(),
+        retries_max   => pos_integer(),
+        streak_target => pos_integer()
+    }.
+wait_for_chain_stall(Miners, Options=#{}) ->
+    State =
+        #{
+            interval      => maps:get(interval, Options, 5000),
+            retries_max   => maps:get(retries_max, Options, 100),
+            streak_target => maps:get(streak_target, Options, 5),
+            streak_prev   => 0,
+            retries_cur   => 0,
+            height_prev   => 0
+         },
+    wait_for_chain_stall_(Miners, State).
+
+wait_for_chain_stall_(_, #{streak_target := Target, streak_prev := Streak}) when Streak >= Target ->
+    ok;
+wait_for_chain_stall_(_, #{retries_cur := Cur, retries_max := Max}) when Cur >= Max ->
+    error;
+wait_for_chain_stall_(
+    Miners,
+    #{
+        interval    := Interval,
+        streak_prev := StreakPrev,
+        height_prev := HeightPrev,
+        retries_cur := RetriesCur
+    }=State0
+) ->
+    {HeightCurr, StreakCurr} =
+        case wait_for_equalized_heights(Miners) of
+            HeightPrev -> {HeightPrev, 1 + StreakPrev};
+            HeightCurr0 -> {HeightCurr0, 0}
+        end,
+    timer:sleep(Interval),
+    State1 = State0#{
+        height_prev := HeightCurr,
+        streak_prev := StreakCurr,
+        retries_cur := RetriesCur + 1
+    },
+    wait_for_chain_stall_(Miners, State1).
+
+-spec wait_for_equalized_heights([node()]) -> non_neg_integer().
+wait_for_equalized_heights(Miners) ->
+    ?assert(
+        miner_ct_utils:wait_until(
+            fun() ->
+                case unique_heights(Miners) of
+                    [_] -> true;
+                    [_|_] -> false
+                end
+            end,
+            50,
+            1000
+        ),
+        "Heights equalized."
+    ),
+    UniqueHeights = unique_heights(Miners),
+    ?assertMatch([_], UniqueHeights, "All heights are equal."),
+    [Height] = UniqueHeights,
+    Height.
 
 stop_miners(Miners) ->
     stop_miners(Miners, 60).
@@ -148,6 +258,10 @@ heights(Miners) ->
                                   {ok, H} = ct_rpc:call(Miner, blockchain, height, [C]),
                                   [{Miner, H} | Acc]
                           end, [], Miners).
+
+-spec unique_heights([node()]) -> [non_neg_integer()].
+unique_heights(Miners) ->
+    lists:usort([H || {_, H} <- miner_ct_utils:heights(Miners)]).
 
 consensus_members([]) ->
     error(no_members);
@@ -599,6 +713,8 @@ init_per_testcase(Mod, TestCase, Config0) ->
             validator_transition_test ->
                 4;
             autoskip_chain_vars_test ->
+                4;
+            autoskip_on_timeout_test ->
                 4;
             _ ->
                 get_config("N", 7)
@@ -1083,7 +1199,8 @@ create_tmp_dir(Path)->
 %% generate a tmp directory based off priv_dir to be used as a scratch by common tests
 %% @end
 %%-------------------------------------------------------------------
--spec init_base_dir_config(atom(), atom(), list()) -> {list(), list()}.
+-spec init_base_dir_config(atom(), atom(), Config) -> Config when
+    Config :: ct_suite:ct_config().
 init_base_dir_config(Mod, TestCase, Config)->
     PrivDir = ?config(priv_dir, Config),
     BaseDir = PrivDir ++ "data/" ++ erlang:atom_to_list(Mod) ++ "_" ++ erlang:atom_to_list(TestCase),


### PR DESCRIPTION
we never time out a round, which means that if some critical messages are lost, we might never proceed.  This code adds time-based voting to skip.

todo: needs to be properly set on restore?