### PR TITLE
Update blessed snap to 888481

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -39,9 +39,9 @@
    {s3_base_url, "https://snapshots.helium.wtf/mainnet"},
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 882721},
+   {blessed_snapshot_block_height, 888481},
    {blessed_snapshot_block_hash,
-     <<116,176,240,96,9,33,57,140,155,11,53,246,224,32,130,230,232,130,241,236,115,56,194,42,246,102,191,63,31,68,70,112>>},
+     <<81,247,174,136,61,127,118,100,11,194,97,73,108,106,246,158,242,78,155,110,246,212,41,166,240,156,63,208,107,228,109,194>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},


### PR DESCRIPTION
```
Height 888481
Hash <<81,247,174,136,61,127,118,100,11,194,97,73,108,106,246,158,242,78,155,
       110,246,212,41,166,240,156,63,208,107,228,109,194>> (<<"51f7ae883d7f76640bc261496c6af69ef24e9b6ef6d429a6f09c3fd06be46dc2">>)
Have true
```

```
$ http get https://api.helium.io/v1/snapshots | jq '.data[0]'
{
  "snapshot_hash": "UfeuiD1_dmQLwmFJbGr2nvJOm2721Cmm8Jw_0GvkbcI",
  "block": 888481
}
```