### PR TITLE
Extend metadata fun to gossip release info

### DIFF
--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -94,33 +94,15 @@ metadata_fun() ->
         case application:get_env(miner, mode, gateway) of
             validator ->
                 Vsn = element(2, hd(release_handler:which_releases(permanent))),
+                Map#{<<"release_version">> => list_to_binary(Vsn)};
+            gateway ->
                 FWRelease = case filelib:is_regular(?LSB_FILE) of
                                 true ->
                                     iolist_to_binary(string:trim(os:cmd(?RELEASE_CMD)));
                                 false ->
                                     <<"unknown">>
                             end,
-                Map#{ <<"release_version">> => list_to_binary(Vsn),
-                      <<"release_info">> => FWRelease };
-            gateway ->
-                case miner_lora:position() of
-                    %% GPS location that's adequately close to the asserted
-                    %% location
-                    {ok, _} ->
-                        Map#{<<"gps_fix_quality">> => <<"good_fix">>};
-                    %% the assert location is too far from the fix
-                    {ok, bad_assert, _} ->
-                        Map#{<<"gps_fix_quality">> => <<"bad_assert">>};
-                    %% no gps fix
-                    {error, no_fix} ->
-                        Map#{<<"gps_fix_quality">> => <<"no_fix">>};
-                    %% no location asserted somehow
-                    {error, not_asserted} ->
-                        Map#{<<"gps_fix_quality">> => <<"not_asserted">>};
-                    %% got nonsense or a hopefully transient error, return nothing
-                    _ ->
-                        Map#{<<"gps_fix_quality">> => <<"no_fix">>}
-                end;
+                Map#{<<"release_info">> => FWRelease};
             _ ->
                 Map
         end


### PR DESCRIPTION
Problem to solve: We currently do not collect any firmware release information from miners in their gossiped metadata. It would be a useful thing to know, especially when validators come online and we do not have the ability to inspect them.

Solution: Collect the firmware release info (if it exists in the expected spot and format)