### PR TITLE
Remove all tpke references

### DIFF
--- a/src/cli/miner_cli_genesis.erl
+++ b/src/cli/miner_cli_genesis.erl
@@ -397,6 +397,7 @@ make_vars() ->
       ?validator_minimum_stake => 10000 * 100000000,
       ?validator_liveness_grace_period => 10,
       ?validator_liveness_interval => 20,
+      ?validator_penalty_filter => 10.0,
       ?dkg_penalty => 1.0,
       ?penalty_history_limit => 100
      }.

--- a/src/cli/miner_cli_genesis.erl
+++ b/src/cli/miner_cli_genesis.erl
@@ -399,5 +399,6 @@ make_vars() ->
       ?validator_liveness_interval => 20,
       ?validator_penalty_filter => 10.0,
       ?dkg_penalty => 1.0,
+      ?tenure_penalty => 1.0,
       ?penalty_history_limit => 100
      }.

--- a/src/handlers/miner_dkg_penalty_handler.erl
+++ b/src/handlers/miner_dkg_penalty_handler.erl
@@ -25,7 +25,7 @@
 
 
 -record(state, {bbas :: #{pos_integer() => hbbft_bba:bba_data()},
-                privkey :: tpke_privkey:privkey(),
+                privkey :: tc_key_share:tc_key_share(),
                 members :: [ libp2p_crypto:pubkey_bin()],
                 f :: pos_integer(),
                 dkg_results :: [boolean(),...],
@@ -198,7 +198,7 @@ callback_message(_, _, _) -> none.
 
 -spec serialize(#state{}) -> binary().
 serialize(State) ->
-    t2b(State#state{privkey=tpke_privkey:serialize(State#state.privkey),
+    t2b(State#state{privkey=tc_key_share:serialize(State#state.privkey),
                     bbas=maps:map(fun(_, BBA) ->
                                           hbbft_bba:serialize(BBA)
                                   end, State#state.bbas)}).
@@ -206,7 +206,7 @@ serialize(State) ->
 -spec deserialize(binary()) -> #state{}.
 deserialize(M) ->
     State0 = binary_to_term(M),
-    PrivKey = tpke_privkey:deserialize(State0#state.privkey),
+    PrivKey = tc_key_share:deserialize(State0#state.privkey),
     State0#state{privkey=PrivKey,
                  bbas=maps:map(fun(_, BBA) ->
                                        hbbft_bba:deserialize(BBA, PrivKey)


### PR DESCRIPTION
Problem: `miner_dkg_penalty_handler` is missing how to handle `tc_key_share:secret_key` [de]ser

Solution: 

- Add `tc_key_share` functions to `miner_dkg_penalty_handler
- Furhter remove all references of `tpke` from miner src, however there's tpke in the lock file which we can remove once we consolidate the ultimate rebar.lock
- Also add `validator_penalty_filter => 10.0` for run.sh support

Test:
- Confirmed run.sh works after stop/start a node in consensus locally