### PR TITLE
Remove all tpke references

### DIFF
--- a/src/cli/miner_cli_genesis.erl
+++ b/src/cli/miner_cli_genesis.erl
@@ -397,6 +397,8 @@ make_vars() ->
       ?validator_minimum_stake => 10000 * 100000000,
       ?validator_liveness_grace_period => 10,
       ?validator_liveness_interval => 20,
+      ?validator_penalty_filter => 10.0,
       ?dkg_penalty => 1.0,
+      ?tenure_penalty => 1.0,
       ?penalty_history_limit => 100
      }.

--- a/src/handlers/miner_dkg_penalty_handler.erl
+++ b/src/handlers/miner_dkg_penalty_handler.erl
@@ -25,7 +25,7 @@
 
 
 -record(state, {bbas :: #{pos_integer() => hbbft_bba:bba_data()},
-                privkey :: tpke_privkey:privkey(),
+                privkey :: tc_key_share:tc_key_share(),
                 members :: [ libp2p_crypto:pubkey_bin()],
                 f :: pos_integer(),
                 dkg_results :: [boolean(),...],
@@ -198,7 +198,7 @@ callback_message(_, _, _) -> none.
 
 -spec serialize(#state{}) -> binary().
 serialize(State) ->
-    t2b(State#state{privkey=tpke_privkey:serialize(State#state.privkey),
+    t2b(State#state{privkey=tc_key_share:serialize(State#state.privkey),
                     bbas=maps:map(fun(_, BBA) ->
                                           hbbft_bba:serialize(BBA)
                                   end, State#state.bbas)}).
@@ -206,7 +206,7 @@ serialize(State) ->
 -spec deserialize(binary()) -> #state{}.
 deserialize(M) ->
     State0 = binary_to_term(M),
-    PrivKey = tpke_privkey:deserialize(State0#state.privkey),
+    PrivKey = tc_key_share:deserialize(State0#state.privkey),
     State0#state{privkey=PrivKey,
                  bbas=maps:map(fun(_, BBA) ->
                                        hbbft_bba:deserialize(BBA, PrivKey)

--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -24,7 +24,7 @@
          f :: non_neg_integer(),
          id :: non_neg_integer(),
          hbbft :: hbbft:hbbft_data(),
-         sk :: tc_key_share:tc_key_share() | tpke_privkey:privkey() | binary(),
+         sk :: tc_key_share:tc_key_share() | binary(),
          sigs_valid     = [] :: addr_sigs(),
          sigs_invalid   = [] :: addr_sigs(),
          sigs_unchecked = [] :: addr_sigs(),
@@ -161,12 +161,7 @@ handle_command({status, Ref, Worker}, State) ->
                        A -> blockchain_utils:bin_to_hex(crypto:hash(sha256, A))
                    end,
     SigMemIds = addr_sigs_to_mem_pos(State#state.sigs_valid, State),
-    PubKeyHash = case tc_key_share:is_key_share(State#state.sk) of
-                     true ->
-                         crypto:hash(sha256, term_to_binary(tc_pubkey:serialize(tc_key_share:public_key(State#state.sk))));
-                     false ->
-                         crypto:hash(sha256, term_to_binary(tpke_pubkey:serialize(tpke_privkey:public_key(State#state.sk))))
-                 end,
+    PubKeyHash = crypto:hash(sha256, term_to_binary(tc_pubkey:serialize(tc_key_share:public_key(State#state.sk)))),
     Worker ! {Ref, maps:merge(#{signatures_required =>
                                     max(State#state.signatures_required - length(SigMemIds), 0),
                                 signatures => SigMemIds,
@@ -396,20 +391,12 @@ serialize(State) ->
 -spec deserialize(binary() | #{atom() => binary()}) -> #state{}.
 deserialize(BinState) when is_binary(BinState) ->
     State = binary_to_term(BinState),
-    SK = try tc_key_share:deserialize(State#state.sk) of
-             Res -> Res
-         catch _:_ ->
-                   tpke_privkey:deserialize(State#state.sk)
-         end,
+    SK = tc_key_share:deserialize(State#state.sk),
     HBBFT = hbbft:deserialize(State#state.hbbft, SK),
     State#state{hbbft=HBBFT, sk=SK};
 deserialize(#{sk := SKSer,
               hbbft := HBBFTSer} = StateMap) ->
-    SK = try tc_key_share:deserialize(binary_to_term(SKSer)) of
-             Res -> Res
-         catch _:_ ->
-                   tpke_privkey:deserialize(binary_to_term(SKSer))
-         end,
+    SK = tc_key_share:deserialize(binary_to_term(SKSer)),
     HBBFT = hbbft:deserialize(HBBFTSer, SK),
     Fields = record_info(fields, state),
     Bundef = term_to_binary(undefined, [compressed]),


### PR DESCRIPTION
Problem: `miner_dkg_penalty_handler` is missing how to handle `tc_key_share:secret_key` [de]ser

Solution: 

- Add `tc_key_share` functions to `miner_dkg_penalty_handler`
- Furhter remove all references of `tpke` from miner src, however there's tpke in the lock file which we can remove once we consolidate the ultimate rebar.lock
- Also updated cli genesis make_vars for run.sh usage

Test:
- Confirmed run.sh works after stop/start a node in consensus locally