### PR TITLE
Treat block opaquely instead of accessing directly

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"2aa156bedd7919d7cacaf57ea8888f5eaa068cce"}},
+       {ref,"29d0f84410e530bf2e39ac2695600aff593b3998"}},
   0},
  {<<"clique">>,
   {git,"https://github.com/helium/clique.git",

--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -15,7 +15,6 @@
         ]).
 
 -include_lib("blockchain/include/blockchain_vars.hrl").
--include_lib("helium_proto/include/blockchain_block_pb.hrl").
 -include("miner_util.hrl").
 
 -record(state,
@@ -585,15 +584,11 @@ state_sigs_maybe_switch_to_varless(#state{}=S) ->
 
 -spec state_remove_var_txns_from_artifact(#state{}) ->
     #state{}.
-state_remove_var_txns_from_artifact(#state{artifact=A0}=S) ->
-    #blockchain_block_v1_pb{transactions=T0}=B = blockchain_block:deserialize(A0),
-    NotVar =
-        fun (#blockchain_txn_pb{txn={vars, _}}) -> false;
-            (#blockchain_txn_pb{txn=_}) -> true
-        end,
-    T1 = lists:filter(NotVar, T0),
-    A1 = blockchain_block:serialize(B#blockchain_block_v1_pb{transactions=T1}),
-    S#state{artifact=A1}.
+state_remove_var_txns_from_artifact(#state{artifact=Art0}=S) ->
+    Block0 = blockchain_block:deserialize(Art0),
+    Block1 = blockchain_block_v1:remove_var_txns(Block0),
+    Art1 = blockchain_block:serialize(Block1),
+    S#state{artifact=Art1}.
 
 -spec state_sigs_add([blockchain_block:signature()], #state{}) -> #state{}.
 state_sigs_add(Sigs, #state{}=S) ->

--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -25,9 +25,9 @@
          id :: non_neg_integer(),
          hbbft :: hbbft:hbbft_data(),
          sk :: tc_key_share:tc_key_share() | binary(),
-         sigs_valid     = [] :: addr_sigs(),
-         sigs_invalid   = [] :: addr_sigs(),
-         sigs_unchecked = [] :: addr_sigs(),
+         sigs_valid     = [] :: [blockchain_block:signature()],
+         sigs_invalid   = [] :: [blockchain_block:signature()],
+         sigs_unchecked = [] :: [blockchain_block:signature()],
          signatures_required = 0,
          sig_phase = unsent :: unsent | sig | gossip | done,
          artifact :: undefined | binary(),
@@ -41,15 +41,6 @@
          swarm_keys :: {libp2p_crypto:pubkey(), libp2p_crypto:sig_fun()}
         }).
 
--type addr() ::
-    libp2p_crypto:pubkey_bin().
-
--type addr_sig() ::
-    {addr(), Sig :: binary()}.
-
--type addr_sigs() ::
-    [addr_sig()].
-
 -type hbbft_msg() ::
       hbbft_msg_signature()
     | hbbft_msg_signatures()
@@ -58,10 +49,10 @@
     | hbbft:sign_msg().
 
 -type hbbft_msg_signature() ::
-    {signature, Round :: pos_integer(), addr(), Sig :: binary()}.
+    {signature, Round :: pos_integer(), libp2p_crypto:pubkey_bin(), Sig :: binary()}.
 
 -type hbbft_msg_signatures() ::
-    {signatures, Round :: pos_integer(), addr_sigs()}.
+    {signatures, Round :: pos_integer(), [blockchain_block:signature()]}.
 
 -spec metadata(V, M, C) -> binary()
     when V :: tuple | map,
@@ -451,7 +442,8 @@ fixup_msgs(Msgs) ->
 %% @doc Finds unique member positions (if any) of addresses in the given
 %% `{Address, Signature}' tuples.
 %% @end
--spec addr_sigs_to_mem_pos(addr_sigs(), #state{}) -> [pos_integer()].
+-spec addr_sigs_to_mem_pos([blockchain_block:signature()], #state{}) ->
+    [pos_integer()].
 addr_sigs_to_mem_pos(AddrSigs, #state{members=MemberAddresses}) ->
     lists:usort(positions([Addr || {Addr, _} <- AddrSigs], MemberAddresses)).
 
@@ -484,7 +476,8 @@ state_reset(HBBFT, #state{}=S) ->
     }.
 
 -spec handle_sigs(
-    {received, addr_sigs()} | {produced, addr_sig(), non_neg_integer()},
+    {received, [blockchain_block:signature()]}
+    | {produced, blockchain_block:signature(), non_neg_integer()},
     #state{}
 ) ->
     {#state{}, [{multicast, binary()}]}.
@@ -515,9 +508,11 @@ handle_sigs(Given, #state{hbbft=HBBFT}=S0) ->
             {S1, fixup_msgs(MsgsOut)}
     end.
 
--spec state_sigs_input(addr_sigs(), #state{}) ->
+-spec state_sigs_input([blockchain_block:signature()], #state{}) ->
     {
-        {done, addr_sigs()} | {gossip, addr_sigs()} | pending,
+        {done, [blockchain_block:signature()]}
+        | {gossip, [blockchain_block:signature()]}
+        | pending,
         #state{}
     }.
 state_sigs_input(SigsIn, #state{hbbft=HBBFT}=S0) ->
@@ -550,7 +545,7 @@ state_sigs_input(SigsIn, #state{hbbft=HBBFT}=S0) ->
     end.
 
 -spec state_sigs_maybe_switch_to_varless(#state{}) ->
-    {{varless, addr_sigs()} | original, #state{}}.
+    {{varless, [blockchain_block:signature()]} | original, #state{}}.
 state_sigs_maybe_switch_to_varless(
     #state{
         artifact     = <<_/binary>>,
@@ -600,11 +595,11 @@ state_remove_var_txns_from_artifact(#state{artifact=A0}=S) ->
     A1 = blockchain_block:serialize(B#blockchain_block_v1_pb{transactions=T1}),
     S#state{artifact=A1}.
 
--spec state_sigs_add(addr_sigs(), #state{}) -> #state{}.
+-spec state_sigs_add([blockchain_block:signature()], #state{}) -> #state{}.
 state_sigs_add(Sigs, #state{}=S) ->
     lists:foldl(fun state_sigs_add_one/2, S, Sigs).
 
--spec state_sigs_add_one(addr_sig(), #state{}) -> #state{}.
+-spec state_sigs_add_one(blockchain_block:signature(), #state{}) -> #state{}.
 state_sigs_add_one({Addr, Sig}, #state{artifact = undefined, sigs_unchecked=Unchecked}=S) ->
     %% Provisionally accept signatures if we don't have the means to
     %% verify them yet. We'll retry verifying them later.
@@ -623,7 +618,9 @@ state_sigs_retry_unchecked(#state{artifact = <<_/binary>>, sigs_unchecked = Unch
 
 -spec state_sigs_check_if_enough(#state{}) ->
     {not_enough | {enough_for, Next}, #state{}} when
-    Next :: {gossip, addr_sigs()} | {done, addr_sigs()}.
+    Next ::
+        {gossip, [blockchain_block:signature()]}
+        | {done, [blockchain_block:signature()]}.
 state_sigs_check_if_enough(#state{artifact=undefined}=S) ->
     {not_enough, S};
 state_sigs_check_if_enough(#state{sig_phase = sig, sigs_valid = Sigs, f = F}=S) when length(Sigs) < F + 1 ->
@@ -673,7 +670,7 @@ state_sigs_check_if_enough(
             {not_enough, S0}
     end.
 
--spec sig_is_valid(addr_sig(), #state{}) -> boolean().
+-spec sig_is_valid(blockchain_block:signature(), #state{}) -> boolean().
 sig_is_valid(
     {<<Addr/binary>>, <<Sig/binary>>}=AddrSig,
     #state{artifact=Art, members=MemberAddresses, hbbft=HBBFT}=S

--- a/test/miner_blockchain_SUITE.erl
+++ b/test/miner_blockchain_SUITE.erl
@@ -244,25 +244,14 @@ autoskip_chain_vars_test(Config) ->
     [Height1] = AllHeights(),
     ?assertMatch(
         ok,
-        miner_ct_utils:wait_for_gte(height, MinersAll, Height1 + 1),
+        miner_ct_utils:wait_for_gte(height, MinersAll, Height1 + 10),
         "Chain has advanced, so autoskip must've worked."
     ),
 
     %% Extra sanity check - no one should've accepted the bogus var:
-    BogusKeyLookupResults =
-        lists:map(
-            fun (Node) ->
-                Chain = ct_rpc:call(Node, blockchain_worker, blockchain, [], 500),
-                Ledger = ct_rpc:call(Node, blockchain, ledger, [Chain]),
-                Result = ct_rpc:call(Node, blockchain, config, [BogusKey, Ledger], 500),
-                ct:pal("Bogus var lookup. Node:~p, Result:~p", [Node, Result]),
-                Result
-            end,
-            MinersAll
-        ),
     ?assertMatch(
         [{error, not_found}],
-        lists:usort(BogusKeyLookupResults),
+        lists:usort(miner_ct_utils:chain_var_lookup_all(BogusKey, MinersAll)),
         "No node accepted the bogus chain var."
     ),
 


### PR DESCRIPTION
The signature type defs and test helper snuck in because I wasn't able to force push fast-enough before #823 got merged.

TODO:
- [x] merge https://github.com/helium/blockchain-core/pull/873
- [x] revert rebar.config core ref to master and rebar upgrade