### PR TITLE
Fix BBA vote default to be everybody completed

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -527,7 +527,10 @@ create_block(Metadata, Txns, HBBFTRound, Chain, VotesNeeded, {MyPubKey, SignFun}
         [{{J, S}, B} || {J, #{seen := S, bba_completion := B}} <- metadata_only_v2(Metadata)],
     {ok, CurrentBlockHash} = blockchain:head_hash(Chain),
     {SeenVectors, BBAs} = lists:unzip(SeenBBAs),
-    BBA = common_enough_or_default(VotesNeeded, BBAs, <<>>),
+    %% if we cannot agree on the BBA results, default to flagging everyone as having completed
+    BBA = common_enough_or_default(VotesNeeded, BBAs,
+                                   blockchain_utils:map_to_bitvector(
+                                     maps:from_list([ {I, true} || I <- lists:seq(1, count_consensus_members(Chain))]))),
     {ElectionEpoch, EpochStart, TxnsToInsert, InvalidTransactions} =
         select_transactions(Chain, Txns, CurrentBlock, HeightCurr, HeightNext),
     NewBlock =


### PR DESCRIPTION
Currently if we cannot agree on a BBA result vector we default to the
empty binary (all 0s). This results in *all* nodes taking a BBA penalty
hit. This is incorrect and this change defaults to the assumption that
everyone completed their BBA so that we do not penalize the entire
group.

This change may cause a "split block" but as long as it merges after the
time based autoskip it should be safe once enough nodes have upgraded.