### PR TITLE
Switch heartbeat txn submission to check validator_version

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -39,9 +39,9 @@
    {s3_base_url, "https://snapshots.helium.wtf/mainnet"},
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 891361},
+   {blessed_snapshot_block_height, 894241},
    {blessed_snapshot_block_hash,
-     <<140,156,39,238,49,99,172,159,24,195,216,10,148,34,255,188,99,183,229,102,195,173,19,215,99,227,96,176,47,7,4,99>>},
+     <<135,31,51,95,65,153,230,236,113,142,25,47,41,152,76,202,66,249,43,102,174,34,134,172,240,113,193,15,0,205,114,199>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},

--- a/src/miner_val_heartbeat.erl
+++ b/src/miner_val_heartbeat.erl
@@ -70,8 +70,8 @@ handle_info({blockchain_event, {add_block, _Hash, _Sync, _Ledger}},
 handle_info({blockchain_event, {add_block, Hash, Sync, _Ledger}},
             #state{address = Address, sigfun = SigFun} = State) ->
     Ledger = blockchain:ledger(State#state.chain),
-    case blockchain:config(?election_version, Ledger) of
-        {ok, V} when V >= 5 ->
+    case blockchain:config(?validator_version, Ledger) of
+        {ok, V} when V >= 1 ->
             {ok, HBInterval} = blockchain:config(?validator_liveness_interval, Ledger),
             Now = erlang:system_time(seconds),
             {ok, Block} = blockchain:get_block(Hash, State#state.chain),


### PR DESCRIPTION
Switch heartbeat txn submission to check `validator_version` instead of `election_version`