### PR TITLE
clarify intention of 'connected' metric in session info

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -139,8 +139,10 @@ block_age() ->
 -spec p2p_status() -> [{Check::string(), Result::string()}].
 p2p_status() ->
     SwarmTID = blockchain_swarm:tid(),
+    In = application:get_env(blockchain, max_inbound_connections, 2),
+    Out = application:get_env(blockchain, outbound_gossip_connections, 6),
     CheckSessions = fun() ->
-                            case (catch length(libp2p_swarm:sessions(SwarmTID)) > 5) of
+                            case (catch length(libp2p_swarm:sessions(SwarmTID)) > ((In + Out) / 2)) of
                                 true -> "yes";
                                 _  -> "no"
                             end
@@ -172,7 +174,7 @@ p2p_status() ->
                   end,
     lists:foldr(fun({Fun, Name}, Acc) ->
                         [{Name, Fun()} | Acc]
-                end, [], [{CheckSessions, "connected"},
+                end, [], [{CheckSessions, "well-connected"},
                           {CheckPublicAddr, "dialable"},
                           {CheckNatType, "nat_type"},
                           {CheckHeight, "height"}]).

--- a/src/miner.erl
+++ b/src/miner.erl
@@ -141,8 +141,16 @@ p2p_status() ->
     SwarmTID = blockchain_swarm:tid(),
     In = application:get_env(blockchain, max_inbound_connections, 2),
     Out = application:get_env(blockchain, outbound_gossip_connections, 6),
+
+    SessionCt =
+        try
+            length(libp2p_swarm:sessions(SwarmTID))
+        catch _:_ ->
+                0
+        end,
+
     CheckSessions = fun() ->
-                            case (catch length(libp2p_swarm:sessions(SwarmTID)) > ((In + Out) / 2)) of
+                            case (SessionCt > ((In + Out) / 2)) of
                                 true -> "yes";
                                 _  -> "no"
                             end
@@ -175,6 +183,7 @@ p2p_status() ->
     lists:foldr(fun({Fun, Name}, Acc) ->
                         [{Name, Fun()} | Acc]
                 end, [], [{CheckSessions, "well-connected"},
+                          {integer_to_list(SessionCt), "sessions"},
                           {CheckPublicAddr, "dialable"},
                           {CheckNatType, "nat_type"},
                           {CheckHeight, "height"}]).


### PR DESCRIPTION
the current "connected" gives users the impression that they're not connected to anything at all.

This PR adds a session count, and changes the verbiage to "well-connected" when the user is connected to more than half of their target connection count.

closes #862 