### PR TITLE
validator reconfigure

### DIFF
--- a/config/docker-testval.config.src
+++ b/config/docker-testval.config.src
@@ -18,6 +18,9 @@
    {honor_quick_sync, false},
    {quick_sync_mode, assumed_valid},
    {validation_width, 8},
+   {block_sync_batch_size, 10},
+   {block_sync_batch_limit, 100},
+   {max_inbound_connections, 32},
    {key, undefined},
    {relay_limit, 100},
    {base_dir, "/var/data"}

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -14,6 +14,9 @@
   [
    {ports, [2154]},
    {validation_width, 8},
+   {block_sync_batch_size, 10},
+   {block_sync_batch_limit, 100},
+   {max_inbound_connections, 32},
    {key, undefined},
    {relay_limit, 100},
    {base_dir, "/var/data"}

--- a/config/sys.config
+++ b/config/sys.config
@@ -93,7 +93,7 @@
    {batch_size, 2500},
    {curve, 'SS512'},
    {block_time, 60000},
-   {late_block_timeout_seconds, 9000},
+   {late_block_timeout_seconds, 900},
    {update_dir, "/opt/miner/update"},
    {election_interval, 30},
    {radio_device, { {127,0,0,1}, 1680,

--- a/config/test_val.config.src
+++ b/config/test_val.config.src
@@ -18,6 +18,10 @@
    {honor_quick_sync, false},
    {quick_sync_mode, assumed_valid},
    {key, undefined},
+   {block_sync_batch_size, 10},
+   {block_sync_batch_limit, 100},
+   {validation_width, 8},
+   {max_inbound_connections, 32},
    {relay_limit, 100},
    {base_dir, "data"}
   ]},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -13,6 +13,10 @@
  {blockchain,
   [
    {ports, [2154]},
+   {block_sync_batch_size, 10},
+   {block_sync_batch_limit, 100},
+   {validation_width, 8},
+   {max_inbound_connections, 32},
    {key, undefined},
    {relay_limit, 100},
    {base_dir, "data"}


### PR DESCRIPTION
- change late block time to 15 minutes, rather than 150 (typo fix)
- increase block sync sizes on validators
- allow more incoming connections on validators