### PR TITLE
Expose ports, pull genesis from S3, fix deb name

### DIFF
--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -21,13 +21,13 @@ ADD . /usr/src/miner/
 
 RUN ./rebar3 as docker tar
 
-RUN mkdir -p /opt/docker
-RUN tar -zxvf _build/docker/rel/*/*.tar.gz -C /opt/docker
 RUN mkdir -p /opt/docker/update
-RUN wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis
-RUN cp genesis /opt/docker/update/genesis
+RUN tar -zxvf _build/docker/rel/*/*.tar.gz -C /opt/docker
+RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM erlang:22.3.2-alpine as runner
+
+EXPOSE 8080 4467
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc apk-tools
 RUN ulimit -n 64000

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -21,16 +21,16 @@ ADD . /usr/src/miner/
 
 RUN ./rebar3 as docker tar
 
-RUN mkdir -p /opt/docker
-RUN tar -zxvf _build/docker/rel/*/*.tar.gz -C /opt/docker
 RUN mkdir -p /opt/docker/update
-RUN wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis
-RUN cp genesis /opt/docker/update/genesis
+RUN tar -zxvf _build/docker/rel/*/*.tar.gz -C /opt/docker
+RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM arm64v8/erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc apk-tools
 RUN ulimit -n 64000
+
+EXPOSE 8080 4467
 
 WORKDIR /opt/miner
 

--- a/.buildkite/scripts/Dockerfile-testval-amd64
+++ b/.buildkite/scripts/Dockerfile-testval-amd64
@@ -21,20 +21,16 @@ ADD . /usr/src/miner/
 
 RUN ./rebar3 as docker_testval tar
 
-RUN mkdir -p /opt/docker
-RUN tar -zxvf _build/docker_testval/rel/*/*.tar.gz -C /opt/docker
 RUN mkdir -p /opt/docker/update
-
-RUN wget https://snapshots.helium.wtf/genesis.testnet
-RUN cp genesis.testnet /opt/docker/update/genesis
-
-#RUN wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis
-#RUN cp genesis /opt/docker/update/genesis
+RUN tar -zxvf _build/docker_testval/rel/*/*.tar.gz -C /opt/docker
+RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.testnet
 
 FROM erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc
 RUN ulimit -n 64000
+
+EXPOSE 8080 4467
 
 WORKDIR /opt/miner
 

--- a/.buildkite/scripts/Dockerfile-testval-arm64
+++ b/.buildkite/scripts/Dockerfile-testval-arm64
@@ -21,20 +21,17 @@ ADD . /usr/src/miner/
 
 RUN ./rebar3 as docker_testval tar
 
-RUN mkdir -p /opt/docker
-RUN tar -zxvf _build/docker_testval/rel/*/*.tar.gz -C /opt/docker
 RUN mkdir -p /opt/docker/update
+RUN tar -zxvf _build/docker_testval/rel/*/*.tar.gz -C /opt/docker
 
-RUN wget https://snapshots.helium.wtf/genesis.testnet
-RUN cp genesis.testnet /opt/docker/update/genesis
-
-# RUN wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis
-# RUN cp genesis /opt/docker/update/genesis
+RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.testnet
 
 FROM arm64v8/erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc
 RUN ulimit -n 64000
+
+EXPOSE 8080 4467
 
 WORKDIR /opt/miner
 

--- a/.buildkite/scripts/Dockerfile-val-amd64
+++ b/.buildkite/scripts/Dockerfile-val-amd64
@@ -21,17 +21,17 @@ ADD . /usr/src/miner/
 
 RUN ./rebar3 as docker_val tar
 
-RUN mkdir -p /opt/docker
-RUN tar -zxvf _build/docker_val/rel/*/*.tar.gz -C /opt/docker
 RUN mkdir -p /opt/docker/update
+RUN tar -zxvf _build/docker_val/rel/*/*.tar.gz -C /opt/docker
 
-RUN wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis
-RUN cp genesis /opt/docker/update/genesis
+RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc
 RUN ulimit -n 64000
+
+EXPOSE 8080 4467
 
 WORKDIR /opt/miner
 

--- a/.buildkite/scripts/Dockerfile-val-arm64
+++ b/.buildkite/scripts/Dockerfile-val-arm64
@@ -21,17 +21,16 @@ ADD . /usr/src/miner/
 
 RUN ./rebar3 as docker_val tar
 
-RUN mkdir -p /opt/docker
-RUN tar -zxvf _build/docker_val/rel/*/*.tar.gz -C /opt/docker
 RUN mkdir -p /opt/docker/update
-
-RUN wget https://github.com/helium/blockchain-api/raw/master/priv/prod/genesis
-RUN cp genesis /opt/docker/update/genesis
+RUN tar -zxvf _build/docker_val/rel/*/*.tar.gz -C /opt/docker
+RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM arm64v8/erlang:22.3.2-alpine as runner
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc
 RUN ulimit -n 64000
+
+EXPOSE 8080 4467
 
 WORKDIR /opt/miner
 

--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 fpm -n validator \
-    -v $(git describe --abbrev=0 --tags | sed -e s/val//) \
+    -v $(git describe --abbrev=0 --tags | sed -e s/valdator//) \
     -s dir \
     -t deb \
     --depends libssl1.1 \


### PR DESCRIPTION
Problems to solve: The Dockerfiles used to build images should expose the internal ports (even though docker still requires you to use `-p` to publish the ports when the container is started) Also we want to standardize on the location of the genesis block download. Finally the validator tag gets mangled by an incomplete regex.