### PR TITLE
Bind JSONRPC to 0.0.0.0 for docker

### DIFF
--- a/config/docker-testval.config.src
+++ b/config/docker-testval.config.src
@@ -44,6 +44,7 @@
   ]},
  {miner,
   [
+   {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
    {mode, validator},
    {stabilization_period, 8000},
    {network, testnet},

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -40,7 +40,7 @@
   ]},
  {miner,
   [
-   {jsonrpc_ip, {0,0,0,0}}, %% bind to host for docker containers
+   {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
    {mode, validator},
    %% these two now disable all the poc stuff
    {use_ebus, false},

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -40,6 +40,7 @@
   ]},
  {miner,
   [
+   {jsonrpc_ip, {0,0,0,0}}, %% bind to host for docker containers
    {mode, validator},
    %% these two now disable all the poc stuff
    {use_ebus, false},

--- a/config/docker.config
+++ b/config/docker.config
@@ -11,7 +11,8 @@
     ]},
   {miner,
     [
-      {use_ebus, false},
+     {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
+     {use_ebus, false},
       {radio_device, { {0,0,0,0}, 1680,
         {0,0,0,0}, 31341} }
     ]}


### PR DESCRIPTION
Fix for #882. If bond to 127.0.0.1, this will only listen within a docker container making it inaccessible.