### PR TITLE
Fix missing key_info fields

### DIFF
--- a/src/miner_keys.erl
+++ b/src/miner_keys.erl
@@ -8,7 +8,9 @@
                        key_slot => non_neg_integer() | undefined,
                        ecdh_fun => libp2p_crypto:ecdh_fun(),
                        sig_fun => libp2p_crypto:sig_fun(),
-                       onboarding_key => string() | undefined
+                       onboarding_key => string() | undefined,
+                       bus => string(),
+                       address => non_neg_integer()
                      }.
 
 -export_type([key_info/0, key_configuration/0]).


### PR DESCRIPTION
Not sure if:
- `address` type is restrictive-enough - can it be 0? less than 0?
- `undefined` is a possible value for each