### PR TITLE
add random peer predicate

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -25,6 +25,7 @@
   ]},
  {libp2p,
   [
+   {random_peer_pred, fun miner_util:random_peer_predicate/1},
    {node_aliases,
     [
      {"/p2p/112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE", "/ip4/52.8.80.146/tcp/2154"},

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -13,6 +13,7 @@
          median/1,
          mark/2,
          metadata_fun/0,
+         random_peer_predicate/1,
          has_valid_local_capability/2
         ]).
 
@@ -112,6 +113,10 @@ metadata_fun() ->
     catch _:_ ->
               #{}
     end.
+
+random_peer_predicate(Peer) ->
+    not libp2p_peer:is_stale(Peer, timer:minutes(360)) andalso
+        maps:get(<<"release_version">>, libp2p_peer:signed_metadata(Peer), undefined) /= undefined.
 
 -spec has_valid_local_capability(Capability :: non_neg_integer(),
                                  Ledger :: blockchain_ledger_v1:ledger())->


### PR DESCRIPTION
it'd be nice to be able to bias the entire  fleet towards gossiping with the validators (as miners never generate blocks now) 

requires: https://github.com/helium/erlang-libp2p/pull/364