### PR TITLE
bump to new snap for miner, exclude validators

### DIFF
--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -12,6 +12,9 @@
   ]},
  {blockchain,
   [
+   {blessed_snapshot_block_height, 910531},
+   {blessed_snapshot_block_hash,
+     <<95,253,152,33,253,132,175,201,16,213,118,213,1,87,113,203,209,242,143,230,104,213,232,83,61,173,201,176,206,176,178,42>>},
    {ports, [2154]},
    {validation_width, 8},
    {block_sync_batch_size, 10},

--- a/config/sys.config
+++ b/config/sys.config
@@ -40,9 +40,9 @@
    {s3_base_url, "https://snapshots.helium.wtf/mainnet"},
    {honor_quick_sync, true},
    {quick_sync_mode, blessed_snapshot},
-   {blessed_snapshot_block_height, 910531},
+   {blessed_snapshot_block_height, 913684},
    {blessed_snapshot_block_hash,
-     <<95,253,152,33,253,132,175,201,16,213,118,213,1,87,113,203,209,242,143,230,104,213,232,83,61,173,201,176,206,176,178,42>>},
+     <<27,116,105,38,249,54,45,74,12,118,145,17,225,250,108,183,83,248,108,78,29,209,160,166,106,246,32,25,14,21,150,142>>},
    {port, 44158},
    {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 15}, {bus, "i2c-1"}, {address, 16#60}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -12,6 +12,9 @@
   ]},
  {blockchain,
   [
+   {blessed_snapshot_block_height, 910531},
+   {blessed_snapshot_block_hash,
+     <<95,253,152,33,253,132,175,201,16,213,118,213,1,87,113,203,209,242,143,230,104,213,232,83,61,173,201,176,206,176,178,42>>},
    {ports, [2154]},
    {block_sync_batch_size, 10},
    {block_sync_batch_limit, 100},


### PR DESCRIPTION
we don't fully trust this snap, and will only apply it to non-consensus nodes until the chain has generated a new snap.