### PR TITLE
Do not expose the JSONRPC and GRPC ports on the miner docker files

### DIFF
--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -27,8 +27,6 @@ RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.main
 
 FROM erlang:22.3.2-alpine as runner
 
-EXPOSE 8080 4467
-
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc apk-tools
 RUN ulimit -n 64000
 

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -30,8 +30,6 @@ FROM arm64v8/erlang:22.3.2-alpine as runner
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc apk-tools
 RUN ulimit -n 64000
 
-EXPOSE 8080 4467
-
 WORKDIR /opt/miner
 
 ENV COOKIE=miner \


### PR DESCRIPTION
A recent change caused the JSONRPC and GRPC ports to be exposed by docker by default, while these shouldn't be exposed on miners. 