### PR TITLE
Port 0 for jsonrpc in test config for run.sh

### DIFF
--- a/config/test.config
+++ b/config/test.config
@@ -23,7 +23,7 @@
  {miner,
   [
    {mode, validator},
-   {jsonrpc_port, 14464},
+   {jsonrpc_port, 0},
    {use_ebus, false},
    {block_time, 500},
    {election_interval, 10},


### PR DESCRIPTION
Setting jsonrpc port 0 for being able to do local `run.sh`, otherwise you run into some `eaddrinuse` errors and none but one test miners boot.