### PR TITLE
JSON/RPC string fixes

### DIFF
--- a/src/jsonrpc/miner_jsonrpc_accounts.erl
+++ b/src/jsonrpc/miner_jsonrpc_accounts.erl
@@ -10,7 +10,8 @@
 %% jsonrpc_handler
 %%
 
-handle_rpc(<<"account_get">>, #{ <<"address">> := Address }) ->
+handle_rpc(<<"account_get">>, #{ <<"address">> := AddressStr }) ->
+    Address = ?B58_TO_BIN(AddressStr),
     Ledger = blockchain:ledger(blockchain_worker:blockchain()),
     GetBalance = fun() ->
                          case blockchain_ledger_v1:find_entry(Address, Ledger) of

--- a/src/jsonrpc/miner_jsonrpc_dkg.erl
+++ b/src/jsonrpc/miner_jsonrpc_dkg.erl
@@ -35,8 +35,8 @@ handle_rpc(<<"dkg_queue">>, []) ->
                                    last_ack := LastAck
                                   } = maps:get(K, Workers),
                                  #{
-                                   address => ?TO_B58(Raw),
-                                   name => ?TO_ANIMAL_NAME(Raw),
+                                   address => ?BIN_TO_B58(Raw),
+                                   name => ?BIN_TO_ANIMAL(Raw),
                                    count => length(V),
                                    connected => Connected,
                                    blocked => not Ready,
@@ -67,8 +67,8 @@ handle_rpc(<<"dkg_running">>, []) ->
             {ok, Block} = blockchain:get_block(Height+Delay, Chain),
             Hash = blockchain_block:hash_block(Block),
             ConsensusAddrs = blockchain_election:new_group(Ledger, Hash, N, Delay),
-            [ #{ name => ?TO_ANIMAL_NAME(A),
-                 address => ?TO_B58(A) }
+            [ #{ name => ?BIN_TO_ANIMAL(A),
+                 address => ?BIN_TO_B58(A) }
               || A <- ConsensusAddrs ]
     end;
 handle_rpc(<<"dkg_next">>, []) ->

--- a/src/jsonrpc/miner_jsonrpc_hbbft.erl
+++ b/src/jsonrpc/miner_jsonrpc_hbbft.erl
@@ -36,8 +36,8 @@ handle_rpc(<<"hbbft_queue">>, []) ->
                 last_ack := LastAck
             } = maps:get(K, Workers),
             #{
-                address => ?TO_B58(Raw),
-                name => ?TO_ANIMAL_NAME(Raw),
+                address => ?BIN_TO_B58(Raw),
+                name => ?BIN_TO_ANIMAL(Raw),
                 count => length(V),
                 connected => Connected,
                 blocked => not Ready,

--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -154,28 +154,6 @@ format_ledger_gateway_entry(Addr, GW, Height, Verbose) ->
 last_challenge(_Height, undefined) -> <<"undefined">>;
 last_challenge(Height, LC) -> Height - LC.
 
-format_ledger_validator(Addr, Val, Ledger, Height) ->
-    Penalties = blockchain_ledger_validator_v1:calculate_penalties(Val, Ledger),
-    OwnerAddress = blockchain_ledger_validator_v1:owner_address(Val),
-    LastHeartbeat = blockchain_ledger_validator_v1:last_heartbeat(Val),
-    Stake = blockchain_ledger_validator_v1:stake(Val),
-    Status = blockchain_ledger_validator_v1:status(Val),
-    Version = blockchain_ledger_validator_v1:version(Val),
-    Tenure = maps:get(tenure, Penalties, 0.0),
-    DKG = maps:get(dkg, Penalties, 0.0),
-    Perf = maps:get(performance, Penalties, 0.0),
-    TotalPenalty = Tenure+Perf+DKG,
-    #{
-        <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
-        <<"name">> => ?BIN_TO_ANIMAL(Addr),
-        <<"address">> => ?BIN_TO_B58(Addr),
-        <<"owner_address">> => ?BIN_TO_B58(OwnerAddress),
-        <<"last_heartbeat">> => Height - LastHeartbeat,
-        <<"stake">> => Stake,
-        <<"status">> => Status,
-        <<"version">> => Version,
-        <<"tenure_penalty">> => Tenure,
-        <<"dkg_penalty">> => DKG,
-        <<"performance_penalty">> => Perf,
-        <<"total_penalty">> => TotalPenalty
-    }.
+format_ledger_validator(Addr, Val, Ledger, Height, Verbose) ->
+    InfoPairs = blockchain_ledger_validator_v1:print(Val, Height, Verbose, Ledger),
+    maps:from_list(InfoPairs ++ [ {name, ?BIN_TO_ANIMAL(Addr)}, {address, ?BIN_TO_B58(Addr)} ]).

--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -74,15 +74,13 @@ handle_rpc(<<"ledger_gateways">>, #{<<"verbose">> := Verbose}) ->
 handle_rpc(<<"ledger_gateways">>, Params) ->
     ?jsonrpc_error({invalid_params, Params});
 handle_rpc(<<"ledger_validators">>, []) ->
-    handle_rpc(<<"ledger_validators">>, #{<<"verbose">> => false});
-handle_rpc(<<"ledger_validators">>, #{<<"verbose">> := Verbose}) ->
     Ledger = get_ledger(),
     {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
     blockchain_ledger_v1:cf_fold(
         validators,
         fun({Addr, BinVal}, Acc) ->
             Val = blockchain_ledger_validator_v1:deserialize(BinVal),
-            [format_ledger_validator(Addr, Val, Ledger, Height, Verbose) | Acc]
+            [format_ledger_validator(Addr, Val, Ledger, Height) | Acc]
         end,
         [],
         Ledger
@@ -156,8 +154,28 @@ format_ledger_gateway_entry(Addr, GW, Height, Verbose) ->
 last_challenge(_Height, undefined) -> <<"undefined">>;
 last_challenge(Height, LC) -> Height - LC.
 
-format_ledger_validator(Addr, Val, Ledger, Height, Verbose) ->
-    maps:from_list([
-        {<<"name">>, blockchain_utils:addr2name(Addr)}
-        | blockchain_ledger_validator_v1:print(Val, Height, Verbose, Ledger)
-    ]).
+format_ledger_validator(Addr, Val, Ledger, Height) ->
+    Penalties = blockchain_ledger_validator_v1:calculate_penalties(Val, Ledger),
+    OwnerAddress = blockchain_ledger_validator_v1:owner_address(Val),
+    LastHeartbeat = blockchain_ledger_validator_v1:last_heartbeat(Val),
+    Stake = blockchain_ledger_validator_v1:stake(Val),
+    Status = blockchain_ledger_validator_v1:status(Val),
+    Version = blockchain_ledger_validator_v1:version(Val),
+    Tenure = maps:get(tenure, Penalties, 0.0),
+    DKG = maps:get(dkg, Penalties, 0.0),
+    Perf = maps:get(performance, Penalties, 0.0),
+    TotalPenalty = Tenure+Perf+DKG,
+    #{
+       <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
+        <<"name">> => ?BIN_TO_ANIMAL(Addr),
+        <<"address">> => ?BIN_TO_B58(Addr),
+        <<"owner_address">> => ?BIN_TO_B58(OwnerAddress),
+        <<"last_heartbeat">> => Height - LastHeartbeat,
+        <<"stake">> => Stake,
+        <<"status">> => Status,
+        <<"version">> => Version,
+        <<"tenure_penalty">> => Tenure,
+        <<"dkg_penalty">> => DKG,
+        <<"performance_penalty">> => Perf,
+        <<"total_penalty">> => TotalPenalty
+    }.

--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -154,7 +154,7 @@ format_ledger_gateway_entry(Addr, GW, Height, Verbose) ->
 last_challenge(_Height, undefined) -> <<"undefined">>;
 last_challenge(Height, LC) -> Height - LC.
 
-format_ledger_validator(Addr, Val, Ledger, Height, Verbose) ->
+format_ledger_validator(Addr, Val, Ledger, Height) ->
     Penalties = blockchain_ledger_validator_v1:calculate_penalties(Val, Ledger),
     OwnerAddress = blockchain_ledger_validator_v1:owner_address(Val),
     LastHeartbeat = blockchain_ledger_validator_v1:last_heartbeat(Val),
@@ -165,14 +165,9 @@ format_ledger_validator(Addr, Val, Ledger, Height, Verbose) ->
     DKG = maps:get(dkg, Penalties, 0.0),
     Perf = maps:get(performance, Penalties, 0.0),
     TotalPenalty = Tenure+Perf+DKG,
-    VerboseItems = case Verbose of
-        true -> #{
-	        <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
-	        <<"name">> => ?BIN_TO_ANIMAL(Addr)
-	    };
-        false -> #{ }
-    end,
-    RegularItems = #{
+    #{
+       <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
+        <<"name">> => ?BIN_TO_ANIMAL(Addr),
         <<"address">> => ?BIN_TO_B58(Addr),
         <<"owner_address">> => ?BIN_TO_B58(OwnerAddress),
         <<"last_heartbeat">> => Height - LastHeartbeat,
@@ -183,5 +178,4 @@ format_ledger_validator(Addr, Val, Ledger, Height, Verbose) ->
         <<"dkg_penalty">> => DKG,
         <<"performance_penalty">> => Perf,
         <<"total_penalty">> => TotalPenalty
-    },
-    maps:merge(VerboseItems, RegularItems).
+    }.

--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -155,5 +155,33 @@ last_challenge(_Height, undefined) -> <<"undefined">>;
 last_challenge(Height, LC) -> Height - LC.
 
 format_ledger_validator(Addr, Val, Ledger, Height, Verbose) ->
-    InfoPairs = blockchain_ledger_validator_v1:print(Val, Height, Verbose, Ledger),
-    maps:from_list(InfoPairs ++ [ {name, ?BIN_TO_ANIMAL(Addr)}, {address, ?BIN_TO_B58(Addr)} ]).
+    Penalties = blockchain_ledger_validator_v1:calculate_penalties(Val, Ledger),
+    OwnerAddress = blockchain_ledger_validator_v1:owner_address(Val),
+    LastHeartbeat = blockchain_ledger_validator_v1:last_heartbeat(Val),
+    Stake = blockchain_ledger_validator_v1:stake(Val),
+    Status = blockchain_ledger_validator_v1:status(Val),
+    Version = blockchain_ledger_validator_v1:version(Val),
+    Tenure = maps:get(tenure, Penalties, 0.0),
+    DKG = maps:get(dkg, Penalties, 0.0),
+    Perf = maps:get(performance, Penalties, 0.0),
+    TotalPenalty = Tenure+Perf+DKG,
+    VerboseItems = case Verbose of
+        true -> #{
+	        <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
+	        <<"name">> => ?BIN_TO_ANIMAL(Addr)
+	    };
+        false -> #{ }
+    end,
+    RegularItems = #{
+        <<"address">> => ?BIN_TO_B58(Addr),
+        <<"owner_address">> => ?BIN_TO_B58(OwnerAddress),
+        <<"last_heartbeat">> => Height - LastHeartbeat,
+        <<"stake">> => Stake,
+        <<"status">> => Status,
+        <<"version">> => Version,
+        <<"tenure_penalty">> => Tenure,
+        <<"dkg_penalty">> => DKG,
+        <<"performance_penalty">> => Perf,
+        <<"total_penalty">> => TotalPenalty
+    },
+    maps:merge(VerboseItems, RegularItems).

--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -166,7 +166,7 @@ format_ledger_validator(Addr, Val, Ledger, Height) ->
     Perf = maps:get(performance, Penalties, 0.0),
     TotalPenalty = Tenure+Perf+DKG,
     #{
-       <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
+        <<"nonce">> => blockchain_ledger_validator_v1:nonce(Val),
         <<"name">> => ?BIN_TO_ANIMAL(Addr),
         <<"address">> => ?BIN_TO_B58(Addr),
         <<"owner_address">> => ?BIN_TO_B58(OwnerAddress),


### PR DESCRIPTION
Fix several points in the JSON/RPC interface where items which should be strings in JSON are instead appearing as lists of integers in result sets and input parameters coming from JSON requests are likewise being misinterpreted by the Erlang.

Fixes #908, where I first noticed the issue.

(This is a re-built branch from cherry-picked commits, to rescue the branch that was original used in PR #911)