### PR TITLE
Clean up JSON/RPC API for proper use of errors and data types.

### DIFF
--- a/src/jsonrpc/miner_jsonrpc_hbbft.erl
+++ b/src/jsonrpc/miner_jsonrpc_hbbft.erl
@@ -58,7 +58,7 @@ handle_rpc(<<"hbbft_perf">>, []) ->
         miner_util:hbbft_perf(),
     [
      #{
-	name => ?TO_VALUE(?TO_ANIMAL_NAME(A)),
+        name => ?TO_VALUE(?TO_ANIMAL_NAME(A)),
         address => ?TO_VALUE(?TO_B58(A)),
         bba_completions => [element(2, maps:get(A, BBATotals)), End+1 - Start],
         seen_votes => [element(2, maps:get(A, SeenTotals)), TotalCount],

--- a/src/jsonrpc/miner_jsonrpc_info.erl
+++ b/src/jsonrpc/miner_jsonrpc_info.erl
@@ -46,7 +46,7 @@ handle_rpc(<<"info_p2p_status">>, []) ->
 handle_rpc(<<"info_region">>, []) ->
     R =
         case miner_lora:region() of
-            {ok, undefined} -> <<"undefined">>;
+            {ok, undefined} -> null;
             {ok, Region} -> atom_to_binary(Region, utf8)
         end,
     #{region => R};

--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -24,7 +24,7 @@ handle_rpc(<<"ledger_balance">>, #{<<"address">> := Address}) ->
     try
         BinAddr = ?B58_TO_BIN(Address),
         case blockchain_ledger_v1:find_entry(BinAddr, get_ledger()) of
-            {error, not_found} -> #{Address => <<"not_found">>};
+            {error, not_found} -> ?jsonrpc_error({not_found, Address});
             {ok, Entry} -> format_ledger_balance(BinAddr, Entry)
         end
     catch
@@ -91,7 +91,7 @@ handle_rpc(<<"ledger_validators">>, #{ <<"address">> := Address }) ->
     try
         BinAddr = ?B58_TO_BIN(Address),
         case blockchain_ledger_v1:get_validator(BinAddr, Ledger) of
-            {error, not_found} -> #{ error => not_found };
+            {error, not_found} -> ?jsonrpc_error({not_found, Address});
             {ok, Val} -> format_ledger_validator(BinAddr, Val, Ledger, Height)
         end
     catch
@@ -113,7 +113,7 @@ handle_rpc(<<"ledger_variables">>, #{ <<"name">> := Name }) ->
             {ok, Var} ->
                 #{ Name => ?TO_VALUE(Var) };
             {error, not_found} ->
-                #{ error => not_found}
+                ?jsonrpc_error({not_found, Name})
         end
     catch
         error:badarg ->
@@ -163,7 +163,7 @@ format_ledger_gateway_entry(Addr, GW, Height, Verbose) ->
             }
     end.
 
-last_challenge(_Height, undefined) -> <<"undefined">>;
+last_challenge(_Height, undefined) -> null;
 last_challenge(Height, LC) -> Height - LC.
 
 format_ledger_validator(Addr, Val, Ledger, Height) ->

--- a/src/jsonrpc/miner_jsonrpc_sc.erl
+++ b/src/jsonrpc/miner_jsonrpc_sc.erl
@@ -9,7 +9,7 @@
 handle_rpc(<<"sc_active">>, []) ->
     case (catch blockchain_state_channels_server:active_sc_ids()) of
         {'EXIT', _} -> ?jsonrpc_error(timeout);
-        undefined -> #{<<"active">> => <<"none">>};
+        undefined -> #{<<"active">> => null};
         BinIds -> #{<<"active">> => [ ?TO_VALUE(base64:encode(I)) || I <- BinIds ]}
     end;
 handle_rpc(<<"sc_active">>, Params) ->
@@ -17,7 +17,7 @@ handle_rpc(<<"sc_active">>, Params) ->
 handle_rpc(<<"sc_list">>, []) ->
     case (catch blockchain_state_channels_server:state_channels()) of
         {'EXIT', _} -> ?jsonrpc_error(timeout);
-        undefined -> #{<<"channels">> => <<"none">>};
+        undefined -> #{<<"channels">> => null};
         SCs -> format_sc_list(SCs)
     end;
 handle_rpc(<<"sc_list">>, Params) ->

--- a/src/jsonrpc/miner_jsonrpc_sc.erl
+++ b/src/jsonrpc/miner_jsonrpc_sc.erl
@@ -9,7 +9,7 @@
 handle_rpc(<<"sc_active">>, []) ->
     case (catch blockchain_state_channels_server:active_sc_ids()) of
         {'EXIT', _} -> ?jsonrpc_error(timeout);
-        undefined -> #{<<"active">> => null};
+        undefined -> #{<<"active">> => []};
         BinIds -> #{<<"active">> => [ ?TO_VALUE(base64:encode(I)) || I <- BinIds ]}
     end;
 handle_rpc(<<"sc_active">>, Params) ->
@@ -17,7 +17,7 @@ handle_rpc(<<"sc_active">>, Params) ->
 handle_rpc(<<"sc_list">>, []) ->
     case (catch blockchain_state_channels_server:state_channels()) of
         {'EXIT', _} -> ?jsonrpc_error(timeout);
-        undefined -> #{<<"channels">> => null};
+        undefined -> #{<<"channels">> => []};
         SCs -> format_sc_list(SCs)
     end;
 handle_rpc(<<"sc_list">>, Params) ->

--- a/src/jsonrpc/miner_jsonrpc_snapshot.erl
+++ b/src/jsonrpc/miner_jsonrpc_snapshot.erl
@@ -14,7 +14,7 @@
 handle_rpc(<<"snapshot_list">>, []) ->
     Chain = blockchain_worker:blockchain(),
     case blockchain:find_last_snapshots(Chain, 5) of
-        undefined -> #{ error => <<"no snapshots found">> };
+        undefined -> ?jsonrpc_error(no_snapshots_found);
         Snapshots ->
             [ #{ height => Height,
                  hash => ?BIN_TO_B64(Hash),

--- a/src/jsonrpc/miner_jsonrpc_txn.erl
+++ b/src/jsonrpc/miner_jsonrpc_txn.erl
@@ -12,7 +12,7 @@
 
 handle_rpc(<<"txn_queue">>, []) ->
     case (catch blockchain_txn_mgr:txn_list()) of
-        {'EXIT', _} -> #{ error => <<"timeout">> };
+        {'EXIT', _} -> ?jsonrpc_error(timeout);
         [] -> [];
         Txns ->
             maps:fold(fun(T, D, Acc) ->
@@ -42,7 +42,7 @@ handle_rpc(<<"txn_add_gateway">>, #{ <<"owner">> := OwnerB58 } = Params) ->
             lager:error("Couldn't do add gateway via JSONRPC because: ~p ~p: ~p",
                         [T, E, St]),
             Error = io_lib:format("~p", [E]),
-            #{ <<"error">> => Error }
+            ?jsonrpc_error({error, Error})
     end;
 handle_rpc(<<"txn_assert_location">>, #{ <<"owner">> := OwnerB58 } = Params) ->
     try
@@ -64,7 +64,7 @@ handle_rpc(<<"txn_assert_location">>, #{ <<"owner">> := OwnerB58 } = Params) ->
             lager:error("Couldn't complete assert location JSONRPC because ~p ~p: ~p",
                         [T, E, St]),
             Error = io_lib:format("~p", [E]),
-            #{ <<"error">> => Error }
+            ?jsonrpc_error({error, Error})
     end;
 handle_rpc(_, _) ->
     ?jsonrpc_error(method_not_found).


### PR DESCRIPTION
Clean up the JSON/RPC API results so that conditional states, missing data
and errors are all easier to detect programmatically. General principles:

* When there is an error, make sure to consistenly use the `?jsonrpc_error()`
  macro.

* If a value is semantically boolean, make it so in the result set. Don't
  return a string.

* If there's no particular error in a query, but there's no data for an item
  then try to use `null` instead of a specialized strings such as "undefined".

* If a query only returns data if the validator/miner is in a specific mode,
  try to ensure that there is a consistently available attribute that
  can be checked _first_ in the result set. Don't make clients try to guess
  the state by checking for the existence of other items, or even worse,
  by checking the returned datatype.

  Example: `dkg_queue`. Before this change, `dkg_queue` either returned

       { "error" : "not running" } (return type is dictionary)
  or

        [ {"name":...,"address":...}, ... ]` (return type is array)

  Now returns either

      { "running": false }
  or

      { "running": true, "consensus_members" : [ ... ] }