### PR TITLE
Add new hardcoded seed node

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -50,7 +50,7 @@
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
-   {seed_nodes, "/ip4/35.166.211.46/tcp/2154,/ip4/44.236.95.167/tcp/2154"},
+   {seed_nodes, "/ip4/35.166.211.46/tcp/2154,/ip4/44.236.95.167/tcp/2154,/ip4/3.34.61.168/tcp/2154"},
    {seed_node_dns, "seed.helium.foundation"},
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},


### PR DESCRIPTION
Problem to solve: There wasn't enough room to include the 4th new seed node (`/ip4/3.34.61.168/tcp/2154`) in the TXT DNS record. We want to include it in the overall list though.

Solution: Hardcode it in the configuration file