### PR TITLE
sharply limit the amount of negative catchup possible

### DIFF
--- a/src/miner.erl
+++ b/src/miner.erl
@@ -768,7 +768,7 @@ set_next_block_timer(State=#state{blockchain=Chain}) ->
     BlockTimeDeviation =
         case BlockTimeDeviation0 of
             N when N > 0 ->
-                max(1, catchup_time(abs(N)));
+                min(1, catchup_time(abs(N)));
             N ->
                 -1 * catchup_time(abs(N))
         end,

--- a/src/miner.erl
+++ b/src/miner.erl
@@ -768,7 +768,7 @@ set_next_block_timer(State=#state{blockchain=Chain}) ->
     BlockTimeDeviation =
         case BlockTimeDeviation0 of
             N when N > 0 ->
-                catchup_time(abs(N));
+                max(1, catchup_time(abs(N)));
             N ->
                 -1 * catchup_time(abs(N))
         end,


### PR DESCRIPTION
The new fast-then-slow strategy of adjustments is interacting badly with the limited lookback period, leading to unwanted oscillations in block times.  Historically, we mostly only have slow blocks; it's possible that any positive period adjustment that exists on the chain is due to these sorts of windowing effects.

This PR limits the amount of negative catchup that we allow ourselves, to acknowledge that we're mostly reacting to slow blocks, and after a smoothing period or two should get us to a place of more regular block times.