### PR TITLE
Readme cleanup, remove link to dead doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,26 @@
 [![Build Status](https://badge.buildkite.com/a2ced4f1160fa02aa8b735e7edb80f8ef787a299963ff88942.svg?branch=master)](https://buildkite.com/helium/miner)
 
-miner quickstart
-=====
+# miner quickstart
 
 Miner for helium blockchain
 
-Build
------
+## Build
 
     $ make
 
-Typecheck
------
+## Typecheck
 
     $ make typecheck
 
-Test
------
+## Test
 
     $ make test
 
-docker
-=====
+# docker
 
 Build a miner-test image locally:
 
-```
+```bash
 docker build -t helium:miner-test -f .buildkite/scripts/Dockerfile-xxxNN .
 ```
 
@@ -33,16 +28,9 @@ Note that Miner for AMD64 requires AVX support on the processor due to the erasu
 
 It is possible to build ARM64 images from an AMD64 machine. Install the following:
 
-```
+```bash
 sudo apt-get install qemu binfmt-support qemu-user-static # Install the qemu packages
 ```
-
-miner step-by-step
-=====
-
-This is a maybe up-to-date step by step on how to build Miner if you've never done it before. Results may vary depending on your host system.
-
-This is for development purposes only and if you are interested in running a miner, please follow our guide [here](https://docs.helium.com/use-the-network/build-a-packet-forwarder#run-the-miner).
 
 ## Installing Miner from Source
 
@@ -88,7 +76,11 @@ sudo dpkg -i esl-erlang_22.1.6-1~raspbian~buster_armhf.deb
 sudo apt-get install -f
 ```
 
-#### Compile the Miner
+Clone the git repository:
+
+```bash
+git clone https://github.com/helium/miner.git
+```
 
 Now it's time to build the miner. This will take a while:
 


### PR DESCRIPTION
As far as I can tell, the 'run a miner' content in docs is gone. I'd be happy to be proven wrong.

Proposing removing the whole block instead of pointing to the gateway-rs guides. It could be nice to reference quay builds in this doc, but it can balloon into a bigger discussion around packet forwarders, etc.

Also took the opportunity to do a little formatting cleanup.

EDIT: Rendered view https://github.com/helium/miner/blob/174f5a692c66dc9ced7eeea1d73398ab97508a7a/README.md