### PR TITLE
New static seed node IPs

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -52,7 +52,7 @@
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
-   {seed_nodes, "/ip4/35.166.211.46/tcp/2154,/ip4/44.236.95.167/tcp/2154,/ip4/3.34.61.168/tcp/2154"},
+   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154"},
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},


### PR DESCRIPTION
Replace the OG seed nodes with new static seed nodes controlled by ansible