### PR TITLE
Refactor hbbft_perf, renaming some confusing variables.

### DIFF
--- a/src/cli/miner_cli_hbbft.erl
+++ b/src/cli/miner_cli_hbbft.erl
@@ -232,18 +232,28 @@ hbbft_perf_usage() ->
     ].
 
 hbbft_perf(["hbbft", "perf"], [], Flags) ->
-    {ConsensusAddrs, BBATotals, SeenTotals, TotalCount, GroupWithPenalties, Start0, Start, End} =
-        miner_util:hbbft_perf(),
+    #{
+        consensus_members := ConsensusMembers,
+        bba_totals := BBATotals,
+        seen_totals := SeenTotals,
+        max_seen := MaxSeen,
+        group_with_penalties := GroupWithPenalties,
+        election_start_height := ElectionStart,
+        epoch_start_height := EpochStart,
+        current_height := CurrentHeight
+    } = miner_util:hbbft_perf(),
+    PostElectionHeight = ElectionStart + 1,
+    BlocksSince = CurrentHeight + 1 - EpochStart,
     [clique_status:table(
        [[{name, element(2, erl_angry_purple_tiger:animal_name(libp2p_crypto:bin_to_b58(A)))} ] ++
             [ {address, libp2p_crypto:pubkey_bin_to_p2p(A)} || lists:keymember(verbose, 1, Flags)] ++
             [
-             {bba_completions, io_lib:format("~b/~b", [element(2, maps:get(A, BBATotals)), End+1 - Start])},
-             {seen_votes, io_lib:format("~b/~b", [element(2, maps:get(A, SeenTotals)), TotalCount])},
-             {last_bba, End - max(Start0 + 1, element(1, maps:get(A, BBATotals)))},
-             {last_seen, End - max(Start0 + 1, element(1, maps:get(A, SeenTotals)))},
+             {bba_completions, io_lib:format("~b/~b", [element(2, maps:get(A, BBATotals)), BlocksSince])},
+             {seen_votes, io_lib:format("~b/~b", [element(2, maps:get(A, SeenTotals)), MaxSeen])},
+             {last_bba, CurrentHeight - max(PostElectionHeight, element(1, maps:get(A, BBATotals)))},
+             {last_seen, CurrentHeight - max(PostElectionHeight, element(1, maps:get(A, SeenTotals)))},
              {tenure, io_lib:format("~.2f", [element(2, element(2, lists:keyfind(A, 1, GroupWithPenalties)))])},
              {penalty, io_lib:format("~.2f", [element(1, element(2, lists:keyfind(A, 1, GroupWithPenalties)))])}
-            ] || A <- ConsensusAddrs])];
+            ] || A <- ConsensusMembers])];
 hbbft_perf([], [], []) ->
     usage.

--- a/src/jsonrpc/miner_jsonrpc_hbbft.erl
+++ b/src/jsonrpc/miner_jsonrpc_hbbft.erl
@@ -54,20 +54,43 @@ handle_rpc(<<"hbbft_queue">>, []) ->
         outbound => Outbound1
     };
 handle_rpc(<<"hbbft_perf">>, []) ->
-    {ConsensusAddrs, BBATotals, SeenTotals, TotalCount, GroupWithPenalties, Start0, Start, End} =
-        miner_util:hbbft_perf(),
-    [
-     #{
-        name => ?TO_VALUE(?TO_ANIMAL_NAME(A)),
-        address => ?TO_VALUE(?TO_B58(A)),
-        bba_completions => [element(2, maps:get(A, BBATotals)), End+1 - Start],
-        seen_votes => [element(2, maps:get(A, SeenTotals)), TotalCount],
-        last_bba => End - max(Start0 + 1, element(1, maps:get(A, BBATotals))),
-        last_seen => End - max(Start0 + 1, element(1, maps:get(A, SeenTotals))),
-        tenure => [element(2, element(2, lists:keyfind(A, 1, GroupWithPenalties)))],
-        penalty => [element(1, element(2, lists:keyfind(A, 1, GroupWithPenalties)))]
-      }
-      || A <- ConsensusAddrs
-    ];
+    #{
+        consensus_members := ConsensusMembers,
+        bba_totals := BBATotals,
+        seen_totals := SeenTotals,
+        max_seen := MaxSeen,
+        group_with_penalties := GroupWithPenalties,
+        election_start_height := ElectionStart,
+        epoch_start_height := EpochStart,
+        current_height := CurrentHeight
+    } = miner_util:hbbft_perf(),
+    PostElectionHeight = ElectionStart + 1,
+    BlocksSince = CurrentHeight + 1 - EpochStart,
+    #{
+        current_height => CurrentHeight,
+        blocks_since_epoch => BlocksSince,
+        max_seen => MaxSeen,
+        consensus_members => [ format_hbbft_entry(Member, CurrentHeight,
+                                                  PostElectionHeight, BBATotals,
+                                                  SeenTotals, GroupWithPenalties) || Member <- ConsensusMembers ]
+    };
 handle_rpc(_, _) ->
     ?jsonrpc_error(method_not_found).
+
+-spec format_hbbft_entry(<<>>, integer(), integer(), map(), map(), list()) -> map().
+format_hbbft_entry(CGMemberAddress, CurrentHeight, PostElectionHeight,
+                   BBATotals, SeenTotals, GroupWithPenalties) ->
+    {LastBBAHeight, Completions} = maps:get(CGMemberAddress, BBATotals),
+    {LastSeenHeight, SeenVotes} = maps:get(CGMemberAddress, SeenTotals),
+    {_Address, {Penalty, Tenure}} = lists:keyfind(CGMemberAddress, 1, GroupWithPenalties),
+    B58Address = ?BIN_TO_B58(CGMemberAddress),
+    #{
+        name => ?B58_TO_ANIMAL(B58Address),
+        address => B58Address,
+        bba_completions => Completions,
+        seen_votes => SeenVotes,
+        last_bba => CurrentHeight - max(PostElectionHeight, LastBBAHeight),
+        last_seen => CurrentHeight - max(PostElectionHeight, LastSeenHeight),
+        tenure => Tenure,
+        penalty => Penalty
+    }.

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -150,20 +150,21 @@ has_valid_local_capability(Capability, Ledger) ->
             end
     end.
 
+-spec hbbft_perf() -> map().
 hbbft_perf() ->
     %% calculate the current election start height
     Chain = blockchain_worker:blockchain(),
     Ledger = blockchain:ledger(Chain),
     {ok, ConsensusAddrs} = blockchain_ledger_v1:consensus_members(Ledger),
     InitMap = maps:from_list([ {Addr, {0, 0}} || Addr <- ConsensusAddrs]),
-    #{start_height := Start0, curr_height := End} = blockchain_election:election_info(Ledger),
-    {Start, GroupWithPenalties} =
+    #{start_height := ElectionStart, curr_height := CurrentHeight } = blockchain_election:election_info(Ledger),
+    {EpochStart, GroupWithPenalties} =
         case blockchain:config(?election_version, Ledger) of
             {ok, N} when N >= 5 ->
                 Penalties = blockchain_election:validator_penalties(ConsensusAddrs, Ledger),
-                Start1 = case End > (Start0 + 2) of
-                             true -> Start0 + 2;
-                             false -> End + 1
+                Start1 = case CurrentHeight > (ElectionStart + 2) of
+                             true -> ElectionStart + 2;
+                             false -> CurrentHeight + 1
                          end,
                 Penalties1 =
                     maps:map(
@@ -174,14 +175,14 @@ hbbft_perf() ->
                       end, Penalties),
                 {Start1, maps:to_list(Penalties1)};
             _ ->
-                {Start0 + 1,
+                {ElectionStart + 1,
                  [{A, {S, 0.0}}
                   || {S, _L, A} <- blockchain_election:adjust_old_group(
                                      [{0, 0, A} || A <- ConsensusAddrs], Ledger)]}
         end,
     Blocks = [begin {ok, Block} = blockchain:get_block(Ht, Chain), Block end
-                    || Ht <- lists:seq(Start, End)],
-    {BBATotals, SeenTotals, TotalCount} =
+                    || Ht <- lists:seq(EpochStart, CurrentHeight)],
+    {BBATotals, SeenTotals, MaxSeen} =
         lists:foldl(
           fun(Blk, {BBAAcc, SeenAcc, Count}) ->
                   H = blockchain_block:height(Blk),
@@ -197,7 +198,16 @@ hbbft_perf() ->
                            end,SeenAcc, SeenVotes),
                   {merge_map(ConsensusAddrs, BBAs, H, BBAAcc), Seen, Count + length(SeenVotes)}
           end, {InitMap, InitMap, 0}, Blocks),
-    {ConsensusAddrs, BBATotals, SeenTotals, TotalCount, GroupWithPenalties, Start0, Start, End}.
+     #{
+         consensus_members => ConsensusAddrs,
+         bba_totals => BBATotals,
+         seen_totals => SeenTotals,
+         max_seen => MaxSeen,
+         group_with_penalties => GroupWithPenalties,
+         election_start_height => ElectionStart,
+         epoch_start_height => EpochStart,
+         current_height => CurrentHeight
+     }.
 
 merge_map(Addrs, Votes, Height, Acc) ->
     maps:fold(fun(K, true, A) ->


### PR DESCRIPTION
Refactor and clean up miner_util:hbbft_perf/0 so that it returns a map, rather than a giant tuple, and rename some of its internal
variables so that they are easier to understand (e.g. "Start0" is now "ElectionStart").

Also clean up the JSON/RPC and the CLI `hbbft perf` endpoints as well.

(Same as #936 but squashed into 1 commit with minor formatting changes)