### PR TITLE
European Router

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -35,8 +35,8 @@
      {"/p2p/112ewJNEUfSg3Jvo276tMjzFC2JzmmZcJJ32CWz2fzYqbyCMMTe1", "/ip4/54.219.236.122/tcp/2154"},
      {"/p2p/1124CJ9yJaHq4D6ugyPCDnSBzQik61C1BqD9VMh1vsUmjwt16HNB", "/ip4/54.176.88.149/tcp/2154"},
      {"/p2p/11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv", "/ip4/54.193.165.228/tcp/2154"},
-     {"/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa", "/ip4/44.238.156.97/tcp/2154"}
-
+     {"/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa", "/ip4/44.238.156.97/tcp/2154"},
+     {"/p2p/11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY", "/ip4/13.37.13.24/tcp/2154"}
     ]}
   ]},
  {blockchain,

--- a/config/sys.config
+++ b/config/sys.config
@@ -102,7 +102,7 @@
    {election_interval, 30},
    {radio_device, { {127,0,0,1}, 1680,
                     {127,0,0,1}, 31341} },
-   {default_routers, ["/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa"]},
+   {default_routers, ["/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa","/p2p/11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY"]},
    {mark_mods, [miner_hbbft_handler]},
    {stabilization_period, 50000},
    {reg_domains_file, "countries_reg_domains.csv"},


### PR DESCRIPTION
Adds European router to `default_router` while also providing entry in `node_aliases`. Can revert the `node_alias` entry if necessary, but would rather test it on a different effort.