### PR TITLE
Fix #1020: difficulties with new semver system and automation.

### DIFF
--- a/.buildkite/scripts/Dockerfile-amd64
+++ b/.buildkite/scripts/Dockerfile-amd64
@@ -23,6 +23,7 @@ RUN ./rebar3 as docker tar
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf _build/docker/rel/*/*.tar.gz -C /opt/docker
+RUN cd /opt/docker/releases && set -- $( cat start_erl.data ) && ln -s $2 current
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM erlang:22.3.2-alpine as runner

--- a/.buildkite/scripts/Dockerfile-arm64
+++ b/.buildkite/scripts/Dockerfile-arm64
@@ -23,6 +23,7 @@ RUN ./rebar3 as docker tar
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf _build/docker/rel/*/*.tar.gz -C /opt/docker
+RUN cd /opt/docker/releases && set -- $( cat start_erl.data ) && ln -s $2 current
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM arm64v8/erlang:22.3.2-alpine as runner

--- a/.buildkite/scripts/Dockerfile-testval-amd64
+++ b/.buildkite/scripts/Dockerfile-testval-amd64
@@ -23,6 +23,7 @@ RUN ./rebar3 as docker_testval tar
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf _build/docker_testval/rel/*/*.tar.gz -C /opt/docker
+RUN cd /opt/docker/releases && set -- $( cat start_erl.data ) && ln -s $2 current
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.testnet
 
 FROM erlang:23.3.4.4-alpine as runner

--- a/.buildkite/scripts/Dockerfile-testval-arm64
+++ b/.buildkite/scripts/Dockerfile-testval-arm64
@@ -23,7 +23,7 @@ RUN ./rebar3 as docker_testval tar
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf _build/docker_testval/rel/*/*.tar.gz -C /opt/docker
-
+RUN cd /opt/docker/releases && set -- $( cat start_erl.data ) && ln -s $2 current
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.testnet
 
 FROM arm64v8/erlang:23.3.4.4-alpine as runner

--- a/.buildkite/scripts/Dockerfile-val-amd64
+++ b/.buildkite/scripts/Dockerfile-val-amd64
@@ -23,7 +23,7 @@ RUN ./rebar3 as docker_val tar
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf _build/docker_val/rel/*/*.tar.gz -C /opt/docker
-
+RUN cd /opt/docker/releases && set -- $( cat start_erl.data ) && ln -s $2 current
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM erlang:23.3.4.4-alpine as runner

--- a/.buildkite/scripts/Dockerfile-val-arm64
+++ b/.buildkite/scripts/Dockerfile-val-arm64
@@ -23,6 +23,7 @@ RUN ./rebar3 as docker_val tar
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf _build/docker_val/rel/*/*.tar.gz -C /opt/docker
+RUN cd /opt/docker/releases && set -- $( cat start_erl.data ) && ln -s $2 current
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.mainnet
 
 FROM arm64v8/erlang:23.3.4.4-alpine as runner


### PR DESCRIPTION
When building the various Docker builds of the miner, create a symlink named "current" which points to the latest, active semantic-versioned configuration directory for the miner.