### PR TITLE
Fix PoC transmission channel selection logic.

### DIFF
--- a/src/poc/miner_onion_server.erl
+++ b/src/poc/miner_onion_server.erl
@@ -379,7 +379,7 @@ decrypt(Type, IV, OnionCompactKey, Tag, CipherText, RSSI, SNR, Frequency, Channe
             case miner_lora:location_ok() of
                 true ->
                     %% the fun below will be executed by miner_lora:send and supplied with the localised lists of channels
-                    ChannelSelectorFun = fun(FreqList) -> lists:nth((IntData rem 8) + 1, FreqList) end,
+                    ChannelSelectorFun = fun(FreqList) -> lists:nth((IntData rem length(FreqList)) + 1, FreqList) end,
                     {ok, Region} = miner_lora:region(),
 
                     case blockchain:config(?poc_version, Ledger) of


### PR DESCRIPTION
Fix a bug that crept in when LoRa region information became more dynamic at runtime: consult the actual channel list size before trying to pick a random element from it, rather than assuming it is exactly 8 elements long.

This is @Vagabond 's patch from Discord on 2021-06-30.

Should fix #1037.