### PR TITLE
compile in pid file

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -81,7 +81,8 @@
          [
           {post_start,
            [
-            {wait_for_process, blockchain_worker}
+            {wait_for_process, blockchain_worker},
+            {pid, "miner.pid"}
            ]}
          ]},
         {extended_start_script, true},


### PR DESCRIPTION
## brief
for the folks out there wanting to run validators outside of docker it would be very useful to have a pid file in place. This will allow us to utilize tools like sysrc more effectively and allow us to opensource upstart scripts.

## This has been compiled and tested with the latest validator beta branch 

```bash
root@casey:~/miner/_build/validator/rel/miner # cat miner.pid
95634
root@casey:~/miner/_build/validator/rel/miner # kill `cat miner.pid`
root@casey:~/miner/_build/validator/rel/miner # kill `cat miner.pid`
95634: No such process

root@casey:~/miner/_build/validator/rel/miner # bin/miner daemon
root@casey:~/miner/_build/validator/rel/miner # cat miner.pid
98007
root@casey:~/miner/_build/validator/rel/miner # kill `cat miner.pid`

```