### PR TITLE
Possible patch for failing region lookup

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -903,6 +903,32 @@ retry_with_rx2(HlmPacket0, From, State) ->
     send_packet(Payload, TS, ChannelSelectorFun, DataRate, Power, true, HlmPacket1, From, State).
 
 -spec maybe_update_reg_data(State :: state()) -> state().
+maybe_update_reg_data(#state{reg_domain_confirmed=true, chain=undefined} = State) ->
+    %% don't have chain, do nothing
+    State;
+maybe_update_reg_data(#state{reg_domain_confirmed=true, chain=Chain} = State) when Chain /= undefined ->
+    case application:get_env(miner, region_override, undefined) of
+        undefined ->
+            %% region is confirmed without region_override
+            %% do nothing
+            State;
+        Region ->
+            %% region was overridden but we have a chain, pull region params from chain if possible
+            case blockchain_region_params_v1:for_region(Region, blockchain:ledger(Chain)) of
+                {ok, RegionParams} ->
+                    FrequencyList = [ (blockchain_region_param_v1:channel_frequency(RP) / ?MHzToHzMultiplier) || RP <- RegionParams ],
+                    State#state{ reg_freq_list = FrequencyList };
+                {error, {not_set, _}} ->
+                    %% TODO: region param vars are not set, default frequency data?
+                    State;
+                {error, Reason} ->
+                    lager:error("unable to find params for region: ~p using chain, error: ~p", [
+                        Region, Reason
+                    ]),
+                    %% TODO: other failure, default frequency data?
+                    State
+            end
+    end;
 maybe_update_reg_data(#state{pubkey_bin=Addr} = State) ->
     case reg_domain_data_for_addr(Addr, State) of
         {error, Reason} ->

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -919,13 +919,14 @@ maybe_update_reg_data(#state{reg_domain_confirmed=true, chain=Chain} = State) wh
                     FrequencyList = [ (blockchain_region_param_v1:channel_frequency(RP) / ?MHzToHzMultiplier) || RP <- RegionParams ],
                     State#state{ reg_freq_list = FrequencyList };
                 {error, {not_set, _}} ->
-                    %% TODO: region param vars are not set, default frequency data?
-                    State;
+                    %% NOTE: region param vars are not set, default frequency data from app env
+                    FreqMap = application:get_env(miner, frequency_data, #{}),
+                    State#state{reg_freq_list=maps:get(Region, FreqMap, undefined)};
                 {error, Reason} ->
                     lager:error("unable to find params for region: ~p using chain, error: ~p", [
                         Region, Reason
                     ]),
-                    %% TODO: other failure, default frequency data?
+                    %% Some other failure, do nothing
                     State
             end
     end;


### PR DESCRIPTION
Reported stacktrace:

```erlang
2021-09-15 03:06:09.564 1 [info] <0.1159.0>@Undefined:Undefined:Undefined Application miner exited with reason: {{shutdown,
{failed_to_start_child,miner_restart_sup,{shutdown,{failed_to_start_child,miner_lora,{badarg,[{ets,lookup,[country_freq_data,
<<"US">>],[]},{miner_lora,reg_domain_data_for_countrycode,1,[{file,"miner_lora.erl"},{line,198}]},
{miner_lora,maybe_update_reg_data,1,[{file,"miner_lora.erl"},{line,907}]},{miner_lora,update_state_using_chain,2,
[{file,"miner_lora.erl"},{line,277}]},{miner_lora,init,1,[{file,"miner_lora.erl"},{line,271}]},{gen_server,init_it,2,[{file,"gen_server.erl"},
{line,...}]},...]}}}}},...}

2021-09-15 03:06:09.645 1 [warning] <0.1498.0>@libp2p_group_gossip_server:handle_cast:241 gossip handler libp2p_peerbook 
failed to init with error {badarg,[{rocksdb,iterator,[#Ref<0.612896675.3939106834.122414>,[]],[]},{libp2p_peerbook,random,4,
[{file,"libp2p_peerbook.erl"},{line,179}]},{libp2p_peerbook,init_gossip_data,1,[{file,"libp2p_peerbook.erl"},{line,368}]},
{libp2p_group_gossip_server,'-handle_cast/2-fun-5-',4,[{file,"libp2p_group_gossip_server.erl"},{line,239}]},{maps,fold_1,3,
[{file,"maps.erl"},{line,233}]},{libp2p_group_gossip_server,handle_cast,2,[{file,"libp2p_group_gossip_server.erl"},{line,238}]},
{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,689}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,765}]}]}

```

Current theory on the crash:

`maybe_update_reg_data` -> `reg_domain_data_for_addr` -> `reg_domain_data_for_countrycode` -> `ets:lookup` -> :boom:

Proposed Solution:

Check whether region is already confirmed, if so, double check if `region_override` was provided, if yes and there's a chain, try to use the chain to lookup region parameters, otherwise do nothing.