### PR TITLE
Fix GA image building

### DIFF
--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 TEST_BUILD=${TEST_BUILD:-0}
 
-ERLANG_IMAGE="23.3.4.6-alpine"
+ERLANG_IMAGE="23.3.4.7-alpine"
 ERLANG_IMAGE_SOURCE="erlang"
 
 BASE_IMAGE="${ERLANG_IMAGE_SOURCE}:${ERLANG_IMAGE}"
@@ -18,10 +18,14 @@ if [[ "$IMAGE_ARCH" == "arm64" ]]; then
     BASE_IMAGE="arm64v8/$BASE_IMAGE"
 fi
 
-MINER_REGISTRY_NAME="$REGISTRY_HOST/team-helium/$REGISTRY_NAME"
-
-VERSION=$(git describe --abbrev=0 | sed -e "s/$BUILD_TYPE//" -e 's/_GA$//' -e 's/+/-/')
+VERSION=$(git describe --abbrev=0 | sed -e "s/$BUILD_TYPE//")
 DOCKER_BUILD_ARGS="--build-arg VERSION=$VERSION"
+
+if [[ $TEST_BUILD ]]; then
+    REGISTRY_NAME="test-builds"
+    DOCKER_BUILD_ARGS="--build-arg REBAR_DIAGNOSTIC=1 $DOCKER_BUILD_ARGS"
+fi
+MINER_REGISTRY_NAME="$REGISTRY_HOST/team-helium/$REGISTRY_NAME"
 
 LATEST_TAG="latest-${IMAGE_ARCH}"
 
@@ -43,12 +47,7 @@ case "$BUILD_TYPE" in
         echo "Doing a miner image build for ${IMAGE_ARCH}"
         DOCKER_BUILD_ARGS="--build-arg EXTRA_BUILD_APK_PACKAGES=apk-tools --build-arg EXTRA_RUNNER_APK_PACKAGES=apk-tools --build-arg BUILDER_IMAGE=${BASE_IMAGE} --build-arg RUNNER_IMAGE=${BASE_IMAGE} --build-arg REBAR_BUILD_TARGET=docker ${DOCKER_BUILD_ARGS}"
         BASE_DOCKER_NAME=$(basename $(pwd))
-        if [[ "$BUILDKITE_TAG" =~ _GA$ ]]; then
-            DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}_GA"
-        else
-            DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
-        fi
-
+        DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
         ;;
     *)
         echo "I don't know how to do a build for ${BUILD_TYPE}"
@@ -61,14 +60,22 @@ if [[ ! $TEST_BUILD ]]; then
     docker login -u="team-helium+buildkite" -p="${QUAY_BUILDKITE_PASSWORD}" ${REGISTRY_HOST}
 fi
 
-# update latest tag if github tag ends in `_GA`
-# and don't do the rest of a build if non-miner build type
-if [[ "$BUILD_TYPE" != "miner" && "$BUILDKITE_TAG" =~ _GA$ ]]; then
+# update latest tag if github tag ends in `_GA` and don't do the rest of a build
+if [[ "$BUILDKITE_TAG" =~ _GA$ ]]; then
 
-    echo "non-miner GA release detected: Updating latest tag on ${REGISTRY_HOST} for ${BUILD_TYPE}"
+    echo "GA release detected: Updating latest tag on ${REGISTRY_HOST} for ${BUILD_TYPE}"
 
-    docker tag helium:$DOCKER_NAME "$MINER_REGISTRY_NAME:$LATEST_TAG"
+    DOCKER_NAME=$(echo "$DOCKER_NAME" | sed -e 's/_GA//')
+
+    docker pull "$MINER_REGISTRY_NAME:$DOCKER_NAME"
+    docker tag "$MINER_REGISTRY_NAME:$DOCKER_NAME" "$MINER_REGISTRY_NAME:$LATEST_TAG"
     docker push "$MINER_REGISTRY_NAME:$LATEST_TAG"
+
+    if [[ "$BUILD_TYPE" == "miner" ]]; then
+        echo "miner GA release detected: Updating 'GA' tag on ${REGISTRY_HOST} for ${VERSION}"
+        docker tag "$MINER_REGISTRY_NAME:$DOCKER_NAME" "$MINER_REGISTRY_NAME:${DOCKER_NAME}_GA"
+        docker push "$MINER_REGISTRY_NAME:${DOCKER_NAME}_GA"
+    fi
 
     exit $?
 fi
@@ -76,13 +83,3 @@ fi
 docker build $DOCKER_BUILD_ARGS -t "helium:${DOCKER_NAME}" .
 docker tag "helium:$DOCKER_NAME" "$MINER_REGISTRY_NAME:$DOCKER_NAME"
 docker push "$MINER_REGISTRY_NAME:$DOCKER_NAME"
-
-# if we're building miner and on a GA tag, push "latest" image tag too.
-if [[ "$BUILDKITE_TAG" =~ _GA$ ]]; then
-
-    echo "GA release detected: Pushing latest on ${REGISTRY_HOST} for $IMAGE_ARCH"
-
-    docker tag helium:$DOCKER_NAME "$MINER_REGISTRY_NAME:$LATEST_TAG"
-    docker push "$MINER_REGISTRY_NAME:$LATEST_TAG"
-
-fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ ARG BUILDER_IMAGE=erlang:23.3.4.6-alpine
 ARG RUNNER_IMAGE=erlang:23.3.4.6-alpine
 FROM ${BUILDER_IMAGE} as builder
 
-ARG REBAR_BUILD_TARGET
+ARG REBAR_DIAGNOSTIC=0
+ENV DIAGNOSTIC=${REBAR_DIAGNOSTIC}
+
 ARG VERSION
+ARG REBAR_BUILD_TARGET
 ARG TAR_PATH=_build/$REBAR_BUILD_TARGET/rel/*/*.tar.gz
 
 ARG EXTRA_BUILD_APK_PACKAGES
@@ -36,6 +39,7 @@ RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.main
 
 FROM ${RUNNER_IMAGE} as runner
 
+ARG VERSION
 ARG EXTRA_RUNNER_APK_PACKAGES
 
 RUN apk add --no-cache --update ncurses dbus gmp libsodium gcc \
@@ -52,6 +56,8 @@ ENV COOKIE=miner \
     PATH=$PATH:/opt/miner/bin
 
 COPY --from=builder /opt/docker /opt/miner
+
+RUN ln -sf /opt/miner/releases/${VERSION} /config
 
 ENTRYPOINT ["/opt/miner/bin/miner"]
 CMD ["foreground"]


### PR DESCRIPTION
Problem to solve: Builds that use _GA tags fail because of the discrepancy between the version without `_GA` and the version relx pulls from git. We also need to make it easier for manufacturers to overlay their own config file(s) without having to navigate the release directory structure in the image.

Solution: Stop stripping `_GA` and only update the tags of docker images. Add a synlink from `/config` to the proper release directory.