### PR TITLE
Testnet 

### DIFF
--- a/src/miner_lora_throttle.erl
+++ b/src/miner_lora_throttle.erl
@@ -40,6 +40,7 @@
     | 'region_as923_1'
     | 'region_as923_2'
     | 'region_as923_3'
+    | 'region_as923_4'
     | 'region_au915'
     | 'region_cn470'
     | 'region_eu433'
@@ -80,6 +81,7 @@ model(Region) ->
         'region_as923_1' -> ?COMMON_DUTY;
         'region_as923_2' -> ?COMMON_DUTY;
         'region_as923_3' -> ?COMMON_DUTY;
+        'region_as923_4' -> ?COMMON_DUTY;
         'region_au915'   -> ?COMMON_DUTY;
         'region_cn470'   -> ?COMMON_DUTY;
         'region_eu433'   -> ?COMMON_DUTY;


### PR DESCRIPTION
Was missing support for 'region_as923_4'  in region types and models, 
so returned ' is not a supported regulatory region'
this affects all miners in Israel and needs resolution ASAP