### PR TITLE
Adjust gain to float and add to summary

### DIFF
--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -156,11 +156,9 @@ format_ledger_gateway_entry(Addr, GW, Height, Verbose) ->
         false ->
             O;
         true ->
-            O#{
-                <<"elevation">> => ?MAYBE(blockchain_ledger_gateway_v2:elevation(GW)),
-                <<"gain">> => ?MAYBE(blockchain_ledger_gateway_v2:gain(GW)),
+            miner_jsonrpc_info:get_gateway_location(undefined, GW, O#{
                 <<"mode">> => ?MAYBE(blockchain_ledger_gateway_v2:mode(GW))
-            }
+            })
     end.
 
 last_challenge(_Height, undefined) -> null;


### PR DESCRIPTION
Adds gain and elevation to jsonrpc info_summary call and adjusts the verbose ledger format to also use the /10 version

Fixes: #1048 (jsonrpc only)