### PR TITLE
Update file handle limit in deb .service file to 128K

### DIFF
--- a/deb/miner.service
+++ b/deb/miner.service
@@ -11,8 +11,8 @@ PIDFile=/var/data/miner/miner.pid
 Environment=HOME="/var/data/miner"
 Environment=RUNNER_LOG_DIR="/var/data/log/miner"
 Environment=ERL_CRASH_DUMP="/var/data/log/miner"
-LimitNOFILE=64000
-LimitNPROC=64000
+LimitNOFILE=128000
+LimitNPROC=128000
 Restart=always
 
 [Install]


### PR DESCRIPTION
Per a conversation with @evan on discord, uppping the
filehandle limits in the deb systemctl .service file
from 64K to 128K

TESTING DONE
I made this change manually in my own service file,
restarted and it seems to work.