### PR TITLE
Bump jsx dep to match core

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
         {dkg, {git, "https://github.com/helium/erlang-dkg.git", {branch, "master"}}},
         {ecc508, {git, "https://github.com/helium/ecc508.git", {branch, "master"}}},
         {ebus, {git, "https://github.com/helium/ebus.git", {branch, "master"}}},
-        {jsx, {git, "https://github.com/talentdeficit/jsx.git", {branch, "v2.8.0"}}},
+        {jsx, "3.1.0"},
         {kvc, {git, "https://github.com/etrepum/kvc", {tag, "v1.7.0"}}},
         {longfi, {git, "https://github.com/helium/longfi-erlang", {tag, "0.2.0"}}},
         recon,


### PR DESCRIPTION
Problem to solve: 2.8.0 is a pretty old release of jsx. We are using 3.1.0 in core.

Solution: match the definition in core