### PR TITLE
Use dBm, not cBm, for EIRP results. More widely understood.

### DIFF
--- a/src/jsonrpc/miner_jsonrpc_ledger.erl
+++ b/src/jsonrpc/miner_jsonrpc_ledger.erl
@@ -244,7 +244,7 @@ format_region_parameter(RegionParam) ->
     #{
         <<"channel_frequency_hz">> => ChannelFrequencyHz,
         <<"bandwidth_hz">> => BandwidthHz,
-        <<"max_eirp_cbm">> => MaxEIRPcBm,
+        <<"max_eirp_dbm">> => MaxEIRPcBm / 10.0,
         <<"spreading">> => SpreadingObject
     }.
 


### PR DESCRIPTION
LoRa region parameters are stored on chain using integers where possible. This extends to EIRP limits, which are stored in a unit that can rightly be called a "centiBel" or "one hundredth of a Bel". Such a unit does indeed exist, but it's obscure and just going to cause problems:

> What is the meaning of cbm here? Or is this a typo and should it be dbm? 

So convert the on-chain value to its more widely understood relative: the deciBel.