### PR TITLE
Ignore all prior pocv11 lookups

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -191,7 +191,7 @@ reg_domain_data_for_addr(Addr, #state{chain=Chain}) ->
                         {error, Reason} ->
                             {error, Reason}
                     end;
-                {error, _Reason} ->
+                _ ->
                     %% before poc-v11
                     lookup_via_country_code(Addr)
             end


### PR DESCRIPTION
Problem
----

Alpha hotspots are failing to boot `miner_lora` because of a missing catch-all clause with error:

```
2021-11-05 00:16:33.108 25239 [error] <0.1463.0>@Undefined:Undefined:Undefined Supervisor miner_sup had child miner_restart_sup started with miner_restart_sup:start_link(#Fun<miner_keys.1.127700184>, #Fun<miner_keys.0.127700184>) at undefined exit with reason {shutdown,{failed_to_start_child,miner_lora,{{case_clause,{ok,10}},[{miner_lora,reg_domain_data_for_addr,2,[{file,"miner_lora.erl"},{line,169}]},{miner_lora,maybe_update_reg_data,1,[{file,"miner_lora.erl"},{line,952}]},{miner_lora,update_state_
using_chain,2,[{file,"miner_lora.erl"},{line,291}]},{miner_lora,init,1,[{file,"miner_lora.erl"},{line,285}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,374}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,342}]},{proc_lib,init_p_do_apply,...}]}}} in context start_error
```

Solution
----

Keep doing old style csv lookup for anything before poc-v11 instead of specifically catching an error