### PR TITLE
update gossip version to 2

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -58,6 +58,7 @@
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},
+   {gossip_version, 2},
    {peerbook_allow_rfc1918, false},
    {metadata_fun, fun miner_util:metadata_fun/0},
    {relay_limit, 50},


### PR DESCRIPTION
Update the gossip version to 2 for all miners and validators.  This activates push gossip, see: https://github.com/helium/blockchain-core/pull/1023 for more details.