### PR TITLE
adjust sizes downward for global caches

### DIFF
--- a/config/docker-testval.config.src
+++ b/config/docker-testval.config.src
@@ -40,8 +40,8 @@
    {mode, validator},
    {stabilization_period, 8000},
    {network, testnet},
-   {rocksdb_cache_size, 64},
-   {rocksdb_write_buffer_size, 64},
+   {rocksdb_cache_size, 32},
+   {rocksdb_write_buffer_size, 32},
    %% these two now disable all the poc stuff
    {use_ebus, false},
    {radio_device, undefined},

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -35,8 +35,8 @@
   [
    {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
    {mode, validator},
-   {rocksdb_cache_size, 64},
-   {rocksdb_write_buffer_size, 64},
+   {rocksdb_cache_size, 32},
+   {rocksdb_write_buffer_size, 32},
    %% these two now disable all the poc stuff
    {use_ebus, false},
    {radio_device, undefined},

--- a/config/test_val.config.src
+++ b/config/test_val.config.src
@@ -40,8 +40,8 @@
    {mode, validator},
    {stabilization_period, 8000},
    {network, testnet},
-   {rocksdb_cache_size, 64},
-   {rocksdb_write_buffer_size, 64},
+   {rocksdb_cache_size, 32},
+   {rocksdb_write_buffer_size, 32},
    %% these two now disable all the poc stuff
    {use_ebus, false},
    {radio_device, undefined},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -35,8 +35,8 @@
  {miner,
   [
    {mode, validator},
-   {rocksdb_cache_size, 64},
-   {rocksdb_write_buffer_size, 64},
+   {rocksdb_cache_size, 32},
+   {rocksdb_write_buffer_size, 32},
    %% these two now disable all the poc stuff
    {use_ebus, false},
    {radio_device, undefined},


### PR DESCRIPTION
there is no big perf gain to be had at 64MB, but it does incur substantial additional memory use, so adjust it downwards some.