### PR TITLE
expanding the blessed seed list

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -54,7 +54,7 @@
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
-   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154"},
+   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154,/ip4/3.66.43.167/tcp/443,/ip4/52.220.121.45/tcp/2154"},
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},


### PR DESCRIPTION
Expands the available list of seed nodes miners can fall back to when DNS lookups fail, spreading the load of peerbook requests between 5 instead of the previous 3 nodes.