### PR TITLE
pass build trigger tag for image version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,8 @@ steps:
 
   - if: build.tag =~ /^validator/
     name: ":debian: build validator deb"
+    env:
+      VERSION_TAG: $BUILDKITE_TAG
     commands:
       - "git fetch -t"
       - ".buildkite/scripts/make_deb.sh"
@@ -22,6 +24,8 @@ steps:
 
   - if: build.tag =~ /^validator/
     name: ":cloud: upload validator deb to packagecloud"
+    env:
+      VERSION_TAG: $BUILDKITE_TAG
     commands:
       - "git fetch -t"
       - ".buildkite/scripts/packagecloud_upload.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,10 +32,11 @@ steps:
   - if: build.tag =~ /^validator/
     name: "validator AMD64 docker"
     env:
+      BUILD_TYPE: "validator"
+      IMAGE_ARCH: "amd64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_NAME: "validator"
-      IMAGE_ARCH: "amd64"
-      BUILD_TYPE: "validator"
+      VERSION_TAG: build.tag
     agents:
       queue: "erlang"
     commands:
@@ -45,10 +46,11 @@ steps:
   - if: build.tag =~ /^validator/
     name: "validator ARM64 docker"
     env:
+      BUILD_TYPE: "validator"
+      IMAGE_ARCH: "arm64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_NAME: "validator"
-      IMAGE_ARCH: "arm64"
-      BUILD_TYPE: "validator"
+      VERSION_TAG: build.tag
     agents:
       queue: "arm64"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
       IMAGE_ARCH: "amd64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_NAME: "validator"
-      VERSION_TAG: build.tag
+      VERSION_TAG: $BUILDKITE_TAG
     agents:
       queue: "erlang"
     commands:
@@ -50,7 +50,7 @@ steps:
       IMAGE_ARCH: "arm64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_NAME: "validator"
-      VERSION_TAG: build.tag
+      VERSION_TAG: $BUILDKITE_TAG
     agents:
       queue: "arm64"
     commands:

--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=$(git describe --abbrev=0 | sed -e 's,validator,,')
+VERSION=$(echo $VERSION_TAG | sed -e 's,validator,,')
 ./rebar3 as validator release -n miner -v ${VERSION}
 
 fpm -n validator \

--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -18,7 +18,7 @@ if [[ "$IMAGE_ARCH" == "arm64" ]]; then
     BASE_IMAGE="arm64v8/$BASE_IMAGE"
 fi
 
-VERSION=$(git describe --abbrev=0 | sed -e "s/$BUILD_TYPE//")
+VERSION=$(echo $VERSION_TAG | sed -e "s/$BUILD_TYPE//")
 DOCKER_BUILD_ARGS="--build-arg VERSION=$VERSION"
 
 if [[ ! $TEST_BUILD -eq "0" ]]; then
@@ -61,7 +61,7 @@ if [[ ! $TEST_BUILD ]]; then
 fi
 
 # update latest tag if github tag ends in `_GA` and don't do the rest of a build
-if [[ "$BUILDKITE_TAG" =~ _GA$ ]]; then
+if [[ "$VERSION_TAG" =~ _GA$ ]]; then
 
     echo "GA release detected: Updating latest tag on ${REGISTRY_HOST} for ${BUILD_TYPE}"
 

--- a/.buildkite/scripts/packagecloud_upload.sh
+++ b/.buildkite/scripts/packagecloud_upload.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-TAG=$( git describe --abbrev=0 --tags | sed -e s/validator// )
+TAG=$(echo $VERSION_TAG | sed -e s/validator// )
 
 PKGNAME="validator_${TAG}_amd64.deb"
 


### PR DESCRIPTION
There seem to be conflicts with concurrent tags being pushed to the miner repo that have caused miner and validator tags to be mixed up on validator images pushed to the public quay repo that need subsequent manual editing to correct. This change should lock in the version of the tag that triggered a build as the tag that gets applied to the images published.