### PR TITLE
transferring seed nodes from dns to sys.config static list

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -54,7 +54,7 @@
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
-   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154,/ip4/3.66.43.167/tcp/443,/ip4/52.220.121.45/tcp/2154"},
+   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154,/ip4/3.66.43.167/tcp/443,/ip4/52.220.121.45/tcp/2154,/ip4/54.207.252.240/tcp/443,/ip4/3.34.10.207/tcp/2154,/ip4/13.238.174.45/tcp/443"},
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},


### PR DESCRIPTION
The DNS response from the seed nodes in the DNS pool is too large; to reduce the load of the lookup response size without losing processing power from the seed pool, we're transferring 3 nodes over to the static config list.