### PR TITLE
Allow for custom API base URL in sys.config

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -102,6 +102,7 @@
    {block_time, 60000},
    {late_block_timeout_seconds, 3600},
    {update_dir, "/opt/miner/update"},
+   {api_base_url, "https://api.helium.io/v1"},
    {election_interval, 30},
    {radio_device, { {127,0,0,1}, 1680,
                     {127,0,0,1}, 31341} },

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -688,7 +688,7 @@ send_to_router(Type, RoutingInfo, Packet, Region) ->
 -spec country_code_for_addr(libp2p_crypto:pubkey_bin()) -> {ok, binary()} | {error, failed_to_find_geodata_for_addr}.
 country_code_for_addr(Addr)->
     B58Addr = libp2p_crypto:bin_to_b58(Addr),
-    URL = "https://api.helium.io/v1/hotspots/" ++ B58Addr,
+    URL = application:get_env(miner, api_base_url, "https://api.helium.io/v1") ++ "/hotspots/" ++ B58Addr,
     case httpc:request(get, {URL, []}, [{timeout, 5000}],[]) of
         {ok, {{_HTTPVersion, 200, _RespBody}, _Headers, JSONBody}} = Resp ->
             lager:debug("hotspot info response: ~p", [Resp]),


### PR DESCRIPTION
Makes the currently hardcoded `https://api.helium.io/v1` API base URL configurable via `sys.config`. This allows using a different API server, effectively removing the pressure on the public, official API service.