### PR TITLE
updating default OTP versions for dockerized miner/validator builds

### DIFF
--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 
 TEST_BUILD=${TEST_BUILD:-0}
 
-ERLANG_IMAGE="23.3.4.7-alpine"
+ERLANG_IMAGE="24-alpine"
 ERLANG_IMAGE_SOURCE="erlang"
 
 BUILD_IMAGE="${ERLANG_IMAGE_SOURCE}:${ERLANG_IMAGE}"
 
-RUN_IMAGE="alpine:3.14.3"
+RUN_IMAGE="alpine:3.14"
 
 if [[ "$IMAGE_ARCH" == "arm64" ]]; then
     BUILD_IMAGE="arm64v8/$BUILD_IMAGE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=erlang:23.3.4.6-alpine
+ARG BUILDER_IMAGE=erlang:24-alpine
 ARG RUNNER_IMAGE=alpine
 FROM ${BUILDER_IMAGE} as builder
 
@@ -42,7 +42,7 @@ FROM ${RUNNER_IMAGE} as runner
 ARG VERSION
 ARG EXTRA_RUNNER_APK_PACKAGES
 
-RUN apk add --no-cache --update ncurses dbus libsodium libgcc libstdc++ \
+RUN apk add --no-cache --update ncurses dbus libsodium libstdc++ \
                                 ${EXTRA_RUNNER_APK_PACKAGES}
 
 RUN ulimit -n 64000


### PR DESCRIPTION
Upgrading dockerized versions of Miner/Validator to default to OTP 24. Also removes libgcc from the build which appears to be unnecessary after comparing to the blockchain-http build.