### PR TITLE
explicitly calling up build tag sha and deleting all but the exact tag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
       VERSION_TAG: $BUILDKITE_TAG
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_deb.sh"
     key: "deb"
     artifact_paths: "*.deb"
@@ -29,7 +29,7 @@ steps:
       VERSION_TAG: $BUILDKITE_TAG
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/packagecloud_upload.sh"
     depends_on: "deb"
     agents:
@@ -47,7 +47,7 @@ steps:
       queue: "erlang"
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_image.sh"
 
   - if: build.tag =~ /^validator/
@@ -62,7 +62,7 @@ steps:
       queue: "arm64"
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_image.sh"
 
   - if: build.tag =~ /^val\d/
@@ -77,7 +77,7 @@ steps:
       queue: "erlang"
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_image.sh"
 
   - if: build.tag =~ /^val\d/
@@ -92,7 +92,7 @@ steps:
       queue: "arm64"
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_image.sh"
 
   - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/
@@ -107,7 +107,7 @@ steps:
       queue: "erlang"
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_image.sh"
 
   - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/
@@ -122,5 +122,5 @@ steps:
       VERSION_TAG: $BUILDKITE_TAG
     commands:
       - "git fetch -t"
-      - "git tag --points-at HEAD | grep -v $BUILDKITE_TAG | xargs -n 1 git tag -d"
+      - "git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | grep -v ^$BUILDKITE_TAG$ | xargs -n 1 git tag -d"
       - ".buildkite/scripts/make_image.sh"


### PR DESCRIPTION
This change aims to address the uncommon situation where a miner build needs to be re-run after additional tags that still match the `grep -v` filter are applied to the same SHA, causing the rebar issue where multi-tagged SHAs are unable to select the correct tag to set the application version.

Also explicitly calls up the SHA of the exact tag being built instead of relying on the HEAD argument pointing to the correct SHA in case additional fetches or other git manipulations go into the build process that could change that value from the SHA that triggered the build in the first place.