### PR TITLE
Disable fetching latest snapshot on validators

### DIFF
--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -13,6 +13,7 @@
  {blockchain,
   [
    {listen_addresses, ["/ip4/0.0.0.0/tcp/2154"]},
+   {fetch_latest_from_snap_source, false},
    {validation_width, "${VALIDATION_WIDTH}"},
    {block_sync_batch_size, 10},
    {block_sync_batch_limit, 100},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -13,6 +13,7 @@
  {blockchain,
   [
    {listen_addresses, ["/ip4/0.0.0.0/tcp/2154"]},
+   {fetch_latest_from_snap_source, false},
    {block_sync_batch_size, 10},
    {block_sync_batch_limit, 100},
    {validation_width, "${VALIDATION_WIDTH}"},


### PR DESCRIPTION
Disable the latest snapshot functionality for syncing validators and instead use only the latest blessed snapshot. Fetching the latest snapshot from a URL creates a security and reliability risk:
1. the hosting URL of the latest snapshot is another attack vector on validators since validators do not have a way to verify the hash of the snapshot
2. not all of the latest snapshots work - as identified in Discord, some of the snapshots cause syncing issues. unlike blessed snapshots, no one reviews or tests the latest snapshots