### PR TITLE
Fix JSONRPC B58 translations for gateway txns.

### DIFF
--- a/src/jsonrpc/miner_jsonrpc_txn.erl
+++ b/src/jsonrpc/miner_jsonrpc_txn.erl
@@ -30,11 +30,11 @@ handle_rpc(<<"txn_queue">>, []) ->
     end;
 handle_rpc(<<"txn_add_gateway">>, #{ <<"owner">> := OwnerB58 } = Params) ->
     try
-        Payer = case maps:get(payer, Params, undefined) of
-                    undefined -> undefined;
-                    PayerB58 -> ?B58_TO_BIN(PayerB58)
-                end,
-        {ok, Bin} = blockchain:add_gateway_txn(?B58_TO_BIN(OwnerB58), Payer),
+        Payer = optional_binary_to_list(
+            maps:get(payer, Params, undefined)
+        ),
+        Owner = binary_to_list(OwnerB58),
+        {ok, Bin} = blockchain:add_gateway_txn(Owner, Payer),
         B64 = base64:encode(Bin),
         #{ <<"result">> => B64 }
     catch
@@ -46,17 +46,16 @@ handle_rpc(<<"txn_add_gateway">>, #{ <<"owner">> := OwnerB58 } = Params) ->
     end;
 handle_rpc(<<"txn_assert_location">>, #{ <<"owner">> := OwnerB58 } = Params) ->
     try
-        Payer = case maps:get(payer, Params, undefined) of
-                    undefined -> undefined;
-                    PayerB58 -> ?B58_TO_BIN(PayerB58)
-                end,
+        Payer = optional_binary_to_list(
+            maps:get(payer, Params, undefined)
+        ),
+        Owner = binary_to_list(OwnerB58),
         H3String = case parse_location(Params) of
                        {error, _} = Err -> throw(Err);
                        {ok, S} -> S
                    end,
         Nonce = maps:get(nonce, Params, 1),
-        {ok, Bin} = blockchain:assert_loc_txn(H3String, ?B58_TO_BIN(OwnerB58),
-                                              Payer, Nonce),
+        {ok, Bin} = blockchain:assert_loc_txn(H3String, Owner, Payer, Nonce),
         B64 = base64:encode(Bin),
         #{ <<"result">> => B64 }
     catch
@@ -68,6 +67,13 @@ handle_rpc(<<"txn_assert_location">>, #{ <<"owner">> := OwnerB58 } = Params) ->
     end;
 handle_rpc(_, _) ->
     ?jsonrpc_error(method_not_found).
+
+-spec optional_binary_to_list(undefined | binary()) -> undefined | string().
+optional_binary_to_list(PossibleBinary) ->
+    case PossibleBinary of
+        undefined -> undefined;
+        Bin       -> binary_to_list(Bin)
+    end.
 
 parse_location(#{ <<"h3">> := H3 }) ->
     try


### PR DESCRIPTION
Fix issue #1118 by properly converting owner and payer addresses into the
format expected by `blockchain:add_gateway_txn` and `blockchain:assert_loc_txn`,
which expect addresses as Erlang B58 strings, not pre-parsed pubkey binaries.