### PR TITLE
updating miner info to grab firmware distro name

### DIFF
--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -426,7 +426,9 @@ get_mac_addrs()->
     Macs.
 
 get_firmware_version()->
-    os:cmd("cat /etc/lsb_release").
+    ReleaseInfo = os:cmd("cat /etc/os-release"),
+    {match, [PrettyName]} = re:run(ReleaseInfo, "PRETTY_NAME=\"(.*)\"", [{capture, all_but_first, list}]),
+    PrettyName.
 
 get_log_errors(ErrorCount, ScanRange)->
     {ok, BaseDir} = application:get_env(lager, log_root),


### PR DESCRIPTION
Updates the miner cli to pull the "firmware" linux disto pretty name from the now-standard `/etc/os-release` file which is in effect across all SystemD distros of linux (our current runtime option being Alpine) and the `/etc/lsb_release` being deprecated and not present on most distros any longer.

I've verified this file is present in most standard distros (Alpine, Ubuntu, Debian, Fedora) so this command should likely succeed in any supported version of Linux that runs miner but I can have it conditionally check for the older `lsb_release` file/command if this file isn't present as well for maximum compatibility.