### PR TITLE
Limit the size and age of rocksdb log files

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -89,7 +89,7 @@
      {db_write_buffer_size, 8388608}, % 8MB
      {max_write_buffer_number, 10},
      {keep_log_file_num, 5},
-     {max_log_file_size, 1048576} %% keep log files 1mb or less
+     {max_log_file_size, 1048576}, %% keep log files 1mb or less
      {log_file_time_to_roll, 86400} %% rotate logs once a day
     ]}
   ]},

--- a/config/sys.config
+++ b/config/sys.config
@@ -88,7 +88,9 @@
      {write_buffer_size, 262144}, % 256kB
      {db_write_buffer_size, 8388608}, % 8MB
      {max_write_buffer_number, 10},
-     {keep_log_file_num, 5}
+     {keep_log_file_num, 5},
+     {max_log_file_size, 1048576} %% keep log files 1mb or less
+     {log_file_time_to_roll, 86400} %% rotate logs once a day
     ]}
   ]},
  {miner,


### PR DESCRIPTION
We've observed extremely large rocksdb log files (1gb+) in the field. We
don't need or want the logs that large, so impose some size and time
rotation limits.