### PR TITLE
Pull seed node IPs from DNS pool

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -27,6 +27,7 @@
   [
    {use_dns_for_seeds, true},
    {seed_dns_cname, "seed.helium.io"},
+   {seed_config_dns_name, "_seed_config.helium.io"},
    {similarity_time_diff_mins, 30},
    {random_peer_pred, fun miner_util:random_val_predicate/1},
    {ip_confirmation_host, "https://ifconfig.co"},
@@ -54,7 +55,7 @@
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
-   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154,/ip4/3.66.43.167/tcp/443,/ip4/52.220.121.45/tcp/2154,/ip4/54.207.252.240/tcp/443,/ip4/3.34.10.207/tcp/2154,/ip4/13.238.174.45/tcp/443,/ip4/18.141.125.188/tcp/2154,/ip4/3.67.159.30/tcp/443,/ip4/44.235.149.49/tcp/2154,/ip4/35.162.25.187/tcp/443,/ip4/54.77.28.37/tcp/2154,/ip4/54.66.57.169/tcp/443,/ip4/54.220.143.223/tcp/2154,/ip4/35.82.232.132/tcp/443,/ip4/13.237.200.108/tcp/2154,/ip4/54.79.185.112/tcp/443,/ip4/52.14.209.51/tcp/2154,/ip4/18.195.81.30/tcp/443,/ip4/54.75.67.249/tcp/2154"},
+   {seed_nodes, "/ip4/18.217.27.26/tcp/2154,/ip4/35.161.222.43/tcp/443,/ip4/99.80.158.114/tcp/2154,/ip4/3.66.43.167/tcp/443,/ip4/52.220.121.45/tcp/2154,/ip4/54.207.252.240/tcp/443,/ip4/3.34.10.207/tcp/2154,/ip4/13.238.174.45/tcp/443"},
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},
    {outbound_gossip_connections, 2},


### PR DESCRIPTION
Problem to solve: In #1267 we added a bunch of static seed nodes until helium/erlang-libp2p#405 was ready to merge. The libp2p PR implementing DNS pools has been merged.

Solution: We now need to remove those static seeds and set the seed config DNS name so that the seed DNS pools can be fetched.