### PR TITLE
persisting 'delete tags' hook so it survives

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# The `post-checkout` hook will run after the bootstrap script has checked out
+# your pipelines source code.
+
+set -euo pipefail
+
+git fetch --tags
+git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | xargs -n 1 git tag -d || true


### PR DESCRIPTION
In the event the buildkite host has any issues with its filesystem (rebuilds or whatnot), this prevents the loss of the the git tag deletion hook that causes so many issues with rebar3 release versioning