### PR TITLE
force fetching tags to avoid 'clobber existing tags' warning

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -5,5 +5,5 @@
 
 set -euo pipefail
 
-git fetch --tags
+git fetch --tags --force # avoid "would clobber existing tags error"
 git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | xargs -n 1 git tag -d || true


### PR DESCRIPTION
Avoids weird edge case where the buildkite workspace _is_ in fact not fully cleaned between builds and the hook's `fetch --tags` command throws an error and crashes the build with an exit 1 when a fetched tag already exists on the host and would be "clobbered".

This was observed when running the "_GA" (i.e. retag Docker image) build job where the tag applied from the previous non-GA build is still present when the current run's post-checkout hook attempts to pull tags again.