### PR TITLE
bump sibyl

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -158,7 +158,7 @@
   3},
  {<<"sibyl">>,
   {git,"https://github.com/helium/sibyl.git",
-       {ref,"2056d33767476b2c2363d6a543279460fed061da"}},
+       {ref,"757d96cd359c2f181728181e04ad5e2aa221875c"}},
   0},
  {<<"small_ints">>,{pkg,<<"small_ints">>,<<"0.1.0">>},4},
  {<<"splicer">>,{pkg,<<"splicer">>,<<"0.5.4">>},2},


### PR DESCRIPTION
Includes fix to remove spurious subscriptions to blockchain events for unary state channel gRPCs

https://github.com/helium/sibyl/commit/a4917b1a8e9b9476214951dca08de7694a1bbf6d
