### PR TITLE
removing add'l directories from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 _build
+.git/
+.buildkite/


### PR DESCRIPTION
Avoiding copying additional unnecessary directories from the source directory into the docker build context