### PR TITLE
Fix #1341

### DIFF
--- a/src/miner_lora_throttle.erl
+++ b/src/miner_lora_throttle.erl
@@ -29,6 +29,10 @@
 
 -type region() ::
     'AS923'
+    | 'AS923_1'
+    | 'AS923_2'
+    | 'AS923_3'
+    | 'AS923_4'
     | 'AU915'
     | 'CN470'
     | 'CN779'
@@ -67,6 +71,10 @@
 model(Region) ->
     case Region of
         'AS923' -> ?COMMON_DUTY;
+        'AS923_1' -> ?COMMON_DUTY;
+        'AS923_2' -> ?COMMON_DUTY;
+        'AS923_3' -> ?COMMON_DUTY;
+        'AS923_4' -> ?COMMON_DUTY;
         'AU915' -> ?COMMON_DUTY;
         'CN470' -> ?COMMON_DUTY;
         'CN779' -> ?COMMON_DUTY;


### PR DESCRIPTION
- Add support for AS923 sub regions

At some point we changed the region CSV to reflect sub AS923 regions (1, 2, 3, 4), but as pointed out in https://github.com/helium/miner/issues/1341 when a user specifies a region override with any of `AS923_*` `miner_throttle` would report unsupported region, this should fix that problem.