### PR TITLE
Increase validator max tcp connections

### DIFF
--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -26,7 +26,8 @@
  {libp2p,
   [
    {random_peer_pred, fun miner_util:true_predicate/1},
-   {nat_map, #{ {"${NAT_INTERNAL_IP}", "${NAT_INTERNAL_PORT}"} => {"${NAT_EXTERNAL_IP}", "${NAT_EXTERNAL_PORT}"}}}
+   {nat_map, #{ {"${NAT_INTERNAL_IP}", "${NAT_INTERNAL_PORT}"} => {"${NAT_EXTERNAL_IP}", "${NAT_EXTERNAL_PORT}"}}},
+   {max_tcp_connections, 2048}
   ]},
  {relcast,
   [

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -26,7 +26,8 @@
  {libp2p,
   [
    {random_peer_pred, fun miner_util:true_predicate/1},
-   {nat_map, #{ {"${NAT_INTERNAL_IP}", "${NAT_INTERNAL_PORT}"} => {"${NAT_EXTERNAL_IP}", "${NAT_EXTERNAL_PORT}"}}}
+   {nat_map, #{ {"${NAT_INTERNAL_IP}", "${NAT_INTERNAL_PORT}"} => {"${NAT_EXTERNAL_IP}", "${NAT_EXTERNAL_PORT}"}}},
+   {max_tcp_connections, 2048}
   ]
  },
  {relcast,


### PR DESCRIPTION
When in consensus group, validators seem to hit up against the default max tcp connection limit of 1024. This PR updates the default configuration for validators to increase the max to 2048. 

The screen shot below shows a validator in CG for 6 rounds. Connections grow over time until they are clipped at 1024 around the 3rd or 4th round. I have observed this on multiple validators and multiple CG tenures. This may be exacerbated by https://github.com/helium/erlang-libp2p/issues/419.

![image](https://user-images.githubusercontent.com/5673441/150048790-d9fbcee8-415d-4bb3-9747-f091a8513b19.png)
