### PR TITLE
bump core, protect more blocks from gc

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -14,8 +14,7 @@
    {relay_limit, 0},
    {base_dir, "data"},
    {snapshot_memory_limit, 2048},
-   {gw_cache_retention_limit, 0},
-   {gw_context_cache_max_size, 0}
+   {blocks_to_protect_from_gc, 10000000}
   ]},
  {miner,
   [

--- a/config/docker-testval.config.src
+++ b/config/docker-testval.config.src
@@ -24,6 +24,7 @@
    {snapshot_memory_limit, 300},
    {key, undefined},
    {relay_limit, 100},
+   {blocks_to_protect_from_gc, 100000},
    {base_dir, "/var/data"}
   ]},
   {libp2p,

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -21,6 +21,7 @@
    {snapshot_memory_limit, 2048},
    {key, undefined},
    {relay_limit, 100},
+   {blocks_to_protect_from_gc, 100000},
    {base_dir, "/var/data"}
   ]},
  {libp2p,

--- a/config/test_val.config.src
+++ b/config/test_val.config.src
@@ -24,6 +24,7 @@
    {max_inbound_connections, 32},
    {snapshot_memory_limit, 300},
    {relay_limit, 100},
+   {blocks_to_protect_from_gc, 100000},
    {base_dir, "data"}
   ]},
  {libp2p,

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -21,6 +21,7 @@
    {snapshot_memory_limit, 2048},
    {key, undefined},
    {relay_limit, 100},
+   {blocks_to_protect_from_gc, 100000},
    {base_dir, "data"}
   ]},
  {libp2p,

--- a/rebar.lock
+++ b/rebar.lock
@@ -5,7 +5,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"3cd6bca6c5595a1363a9bbd625ef254383a4141b"}},
+       {ref,"616d2e42311fc20321c5c0371a548aa66e9b7f22"}},
   0},
  {<<"chatterbox">>,
   {git,"https://github.com/andymck/chatterbox",


### PR DESCRIPTION
for time stabilization, we should keep more blocks on validators, + disable on dev nodes.