### PR TITLE
Enable _alpha, _beta tags on docker registry

### DIFF
--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -78,7 +78,7 @@ if [[ "$BUILD_TYPE" == "miner" ]]; then
         UPDATE_TAG="latest"
     elif [[ "$VERSION_TAG" =~ _alpha$ ]]; then
         UPDATE_TAG="alpha"
-    elif [["$VERSION_TAG" =~ _beta$ ]]; then
+    elif [[ "$VERSION_TAG" =~ _beta$ ]]; then
         UPDATE_TAG="beta"
     fi
 


### PR DESCRIPTION
Problem to solve: We want to publish and update `alpha-$ARCH` and `beta-$ARCH` tags on quay (our docker registry) to support miner test images on our test hotspot fleet.

Solution: Look for `_alpha` or `_beta` on Git Hub tags and then update an image appropriately on quay.