### PR TITLE
configuring new denylist on docker release profile

### DIFF
--- a/config/docker.config
+++ b/config/docker.config
@@ -11,9 +11,12 @@
     ]},
   {miner,
     [
+     {denylist_keys, ["1SbEYKju337P6aYsRd9DT2k4qgK5ZK62kXbSvnJgqeaxK3hqQrYURZjL"]},
+     {denylist_type, github_release},
+     {denylist_url, "https://api.github.com/repos/helium/denylist/releases/latest"},
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
-     {use_ebus, false},
-      {radio_device, { {0,0,0,0}, 1680,
-        {0,0,0,0}, 31341} }
+     {radio_device, { {0,0,0,0}, 1680,
+        {0,0,0,0}, 31341} },
+     {use_ebus, false}
     ]}
 ].


### PR DESCRIPTION
The current poc_denylist worker is deployed but not configured in all miner releases. This configuration change will enable the denylist worker to kick off and start running in releases produced with the docker rebar profile, leaving other releases disabled by default.