### PR TITLE
default denylist in sysconfig, disable explicitly

### DIFF
--- a/config/aws.config
+++ b/config/aws.config
@@ -18,6 +18,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {use_ebus, false},
    {block_time, 1000},
    {election_interval, 15},

--- a/config/dev.config
+++ b/config/dev.config
@@ -18,6 +18,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {jsonrpc_port, 0},
    {use_ebus, false},
    {block_time, 3000},
@@ -31,6 +32,5 @@
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
    {region_override, 'US915'}
-
   ]}
 ].

--- a/config/docker-testval.config.src
+++ b/config/docker-testval.config.src
@@ -37,6 +37,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
    {mode, validator},
    {stabilization_period, 8000},
@@ -51,6 +52,5 @@
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
    {region_override, 'US915'}
-
   ]}
 ].

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -36,6 +36,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
    {mode, validator},
    {rocksdb_cache_size, 32},

--- a/config/docker.config
+++ b/config/docker.config
@@ -11,9 +11,6 @@
     ]},
   {miner,
     [
-     {denylist_keys, ["1SbEYKju337P6aYsRd9DT2k4qgK5ZK62kXbSvnJgqeaxK3hqQrYURZjL"]},
-     {denylist_type, github_release},
-     {denylist_url, "https://api.github.com/repos/helium/denylist/releases/latest"},
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
      {radio_device, { {0,0,0,0}, 1680,
         {0,0,0,0}, 31341} },

--- a/config/seed.config
+++ b/config/seed.config
@@ -26,6 +26,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {use_ebus, false},
    {block_time, 1000},
    {election_interval, 15},

--- a/config/sys.config
+++ b/config/sys.config
@@ -95,6 +95,9 @@
   ]},
  {miner,
   [
+   {denylist_keys, ["1SbEYKju337P6aYsRd9DT2k4qgK5ZK62kXbSvnJgqeaxK3hqQrYURZjL"]},
+   {denylist_type, github_release},
+   {denylist_url, "https://api.github.com/repos/helium/denylist/releases/latest"},
    {jsonrpc_ip, {127,0,0,1}}, %% bind JSONRPC to localhost only
    {jsonrpc_port, 4467},
    {mode, gateway},

--- a/config/test.config
+++ b/config/test.config
@@ -34,6 +34,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {mode, validator},
    {jsonrpc_port, 0},
    {use_ebus, false},

--- a/config/test_val.config.src
+++ b/config/test_val.config.src
@@ -38,6 +38,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {mode, validator},
    {stabilization_period, 8000},
    {network, testnet},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -37,6 +37,7 @@
   ]},
  {miner,
   [
+   {denylist_keys, undefined},
    {mode, validator},
    {rocksdb_cache_size, 32},
    {rocksdb_write_buffer_size, 32},


### PR DESCRIPTION
We need to be able to carry the new denylist configs into firmware builds that overwrite the `docker.config` file since this behavior needs to be the default for any dockerized miner that _doesn't_ explicitly want to disable it by mounting a custom config over the one that ships with the image.

This change moves the denylist miner application configs into the default sys.config file and then explicitly disables it in the non-miner config profiles.