### PR TITLE
deb package enhancements

### DIFF
--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
+BUILD_NET="${BUILD_NET:-mainnet}"
+
+
 VERSION=$(echo $VERSION_TAG | sed -e 's,validator,,')
 DIAGNOSTIC=1 ./rebar3 as validator release -n miner -v ${VERSION} || ./rebar3 as validator release -n miner -v ${VERSION}
+
+wget -O /tmp/genesis https://snapshots.helium.wtf/genesis.${BUILD_NET}
 
 fpm -n validator \
     -v "${VERSION}" \
@@ -11,6 +16,22 @@ fpm -n validator \
     -t deb \
     --depends libssl1.1 \
     --depends libsodium23 \
+    --depends libncurses5 \
+    --depends dbus \
+    --depends libstdc++6 \
     --deb-systemd deb/miner.service \
+    --before-install deb/before_install.sh \
+    --after-install deb/after_install.sh \
+    --after-remove deb/after_remove.sh \
+    --before-upgrade deb/before_upgrade.sh \
+    --after-upgrade deb/after_upgrade.sh \
     --deb-no-default-config-files \
-    _build/validator/rel/=/var/helium
+    --deb-systemd-enable \
+    --deb-systemd-auto-start \
+    --deb-systemd-restart-after-upgrade \
+    --deb-user helium \
+    --deb-group helium \
+    _build/validator/rel/=/opt \
+    /tmp/genesis=/opt/miner/update/genesis
+
+rm -f /tmp/genesis

--- a/.buildkite/scripts/packagecloud_upload.sh
+++ b/.buildkite/scripts/packagecloud_upload.sh
@@ -9,6 +9,6 @@ PKGNAME="validator_${TAG}_amd64.deb"
 buildkite-agent artifact download ${PKGNAME} .
 
 curl -u "${PACKAGECLOUD_API_KEY}:" \
-     -F "package[distro_version_id]=190" \
+     -F "package[distro_version_id]=210" \
      -F "package[package_file]=@${PKGNAME}" \
      https://packagecloud.io/api/v1/repos/helium/validators/packages.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ data
 \#*
 src/pb
 .repos/
+*.deb
 
 # make build output for external deps
 external/

--- a/deb/after_install.sh
+++ b/deb/after_install.sh
@@ -1,0 +1,13 @@
+# add miner to /usr/local/bin it appears in path
+ln -s /opt/miner/bin/miner /usr/local/bin/miner
+
+# if upgrading from old version with different file location, move miner date files to the new location
+if [ -e /var/helium/miner/data/miner/swarm_key ] && [ ! -e /opt/miner/data/miner/swarm_key ]; then
+    echo "Found existing swarm_key, moving data to /opt/miner/"
+    mv /var/helium/miner/data /opt/miner/data
+    chown -R helium:helium /opt/miner/data
+elif [ -e /var/data/miner/miner/swarm_key ] && [ ! -e /opt/miner/data/miner/swarm_key ]; then
+    echo "Found existing swarm_key, moving data to /opt/miner/"
+    mv /var/data/miner /opt/miner/data
+    chown -R helium:helium /opt/miner/data
+fi

--- a/deb/after_remove.sh
+++ b/deb/after_remove.sh
@@ -1,0 +1,1 @@
+rm -f /usr/local/bin/miner

--- a/deb/after_upgrade.sh
+++ b/deb/after_upgrade.sh
@@ -1,0 +1,13 @@
+# if upgrading from old version with different file location, move miner date files to the new location
+if [ -e /var/helium/miner/data/miner/swarm_key ] && [ ! -e /opt/miner/data/miner/swarm_key ]; then
+    echo "Found existing swarm_key, moving data to /opt/miner/"
+    mv /var/helium/miner/data /opt/miner/data
+    chown -R helium:helium /opt/miner/data
+elif [ -e /var/data/miner/miner/swarm_key ] && [ ! -e /opt/miner/data/miner/swarm_key ]; then
+    echo "Found existing swarm_key, moving data to /opt/miner/"
+    mv /var/data/miner /opt/miner/data
+    chown -R helium:helium /opt/miner/data
+fi
+
+# add miner to /usr/local/bin so it appears in path, if it does not already exist
+ln -s /opt/miner/bin/miner /usr/local/bin/miner || true

--- a/deb/before_install.sh
+++ b/deb/before_install.sh
@@ -1,0 +1,2 @@
+# add system user for file ownership and systemd user, if not exists
+useradd --system helium || true

--- a/deb/before_upgrade.sh
+++ b/deb/before_upgrade.sh
@@ -1,0 +1,2 @@
+# add system user for file ownership and systemd user, if not exists
+useradd --system helium || true

--- a/deb/miner.service
+++ b/deb/miner.service
@@ -4,13 +4,14 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/var/helium/miner/bin/miner foreground
-ExecStop=/var/helium/miner/bin/miner stop
-User=ubuntu
-PIDFile=/var/data/miner/miner.pid
-Environment=HOME="/var/data/miner"
-Environment=RUNNER_LOG_DIR="/var/data/log/miner"
-Environment=ERL_CRASH_DUMP="/var/data/log/miner"
+ExecStart=/opt/miner/bin/miner foreground
+ExecStop=/opt/miner/bin/miner stop
+User=helium
+PIDFile=/var/miner/miner.pid
+Environment=HOME="/opt/miner"
+Environment=RUNNER_LOG_DIR="/opt/miner/log"
+Environment=ERL_CRASH_DUMP="/opt/miner/log"
+Environment=RELX_OUT_FILE_PATH="/tmp"
 LimitNOFILE=128000
 LimitNPROC=128000
 Restart=always


### PR DESCRIPTION
The deb package provides an alternative to building from source or running as docker. This PR attempts to improve the usability of the package for validator operators with the following changes:

1. Changes the file install location to `/opt/miner` to match defaults in sys.config and enable adding genesis block
2. Includes the genesis file in the package at `/opt/miner/update` so it automatically gets loaded. Selects network based on BUILD_NET arg, default=mainnet (see also issue #1385 )
3. Enables and runs the systemd service after install
4. Changes user and group to `helium` for running the miner and file ownership. User and group are created as part of before-install script. Previously the miner was run as `ubuntu` which may not exists for all operators. (issue #1061 )
5. Adds symlink in `/usr/local/bin/` to the miner executable for ease of use running miner commands
6. Updates the target distro in the packagecloud repo from Ubuntu 18.04 LTS to 20.04 LTS

Thanks to @kellybyrd and @ericjohncarlson for support on these changes.