### PR TITLE
preserving and pushing _GA-suffixed tags

### DIFF
--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -86,11 +86,16 @@ if [[ "$BUILD_TYPE" == "miner" ]]; then
         echo "Miner tag update detected; Updating ${UPDATE_TAG} on ${REGISTRY_HOST}..."
 
         UPDATE_TAG="${UPDATE_TAG}-${IMAGE_ARCH}"
-        DOCKER_NAME=$(echo "$DOCKER_NAME" | sed -e 's/_GA//' -e 's/_alpha//' -e 's/_beta//')
+        SEMVER_TAG=$(echo "$DOCKER_NAME" | sed -e 's/_GA//' -e 's/_alpha//' -e 's/_beta//')
 
-        docker pull "$MINER_REGISTRY_NAME:$DOCKER_NAME"
-        docker tag "$MINER_REGISTRY_NAME:$DOCKER_NAME" "$MINER_REGISTRY_NAME:$UPDATE_TAG"
+        docker pull "$MINER_REGISTRY_NAME:$SEMVER_TAG"
+        docker tag "$MINER_REGISTRY_NAME:$SEMVER_TAG" "$MINER_REGISTRY_NAME:$UPDATE_TAG"
         docker push "$MINER_REGISTRY_NAME:$UPDATE_TAG"
+
+        if [["$VERSION_TAG" =~ _GA$]]; then
+            docker tag "$MINER_REGISTRY_NAME:$SEMVER_TAG" "$MINER_REGISTRY_NAME:$DOCKER_NAME"
+            docker push "$MINER_REGISTRY_NAME:$DOCKER_NAME"
+        fi
 
         exit $?
     fi


### PR DESCRIPTION
Ensure docker tag builds triggered by a `_GA` git tag carry into the docker artifact pushed to the quay registry for makers that trigger deployments and/or releases based on explicit GA'd semvers instead of a floating `latest` tag release.

Addresses issue #1409 