### PR TITLE
CI: special-case git tags ending with "_testnet"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,7 +96,7 @@ steps:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"
 
-  - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/
+  - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/ && build.tag !~ /_testnet\$/
     name: ":whale: AMD64 docker"
     env:
       BUILD_TYPE: "miner"
@@ -112,7 +112,7 @@ steps:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"
 
-  - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/
+  - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/ && build.tag !~ /_testnet\$/
     name: ":whale: ARM64 docker"
     agents:
       queue: "arm64"
@@ -124,6 +124,44 @@ steps:
       REGISTRY_NAME: "miner"
       VERSION_TAG: $BUILDKITE_TAG
       BUILD_NET: "mainnet"
+    commands:
+      - "git tag $BUILDKITE_TAG"
+      - ".buildkite/scripts/make_image.sh"
+
+  # Miner ARM64 testnet
+  #
+  # Does not start with "val" but does end with "_testnet"
+  - if: build.tag !~ /^val/ && build.tag =~ /_testnet\$/
+    name: ":whale: testnet ARM64 docker"
+    agents:
+      queue: "arm64"
+    env:
+      BUILD_TYPE: "miner"
+      IMAGE_ARCH: "arm64"
+      REGISTRY_HOST: "quay.io"
+      REGISTRY_ORG: "team-helium"
+      REGISTRY_NAME: "testnet"
+      VERSION_TAG: $BUILDKITE_TAG
+      BUILD_NET: "testnet"
+    commands:
+      - "git tag $BUILDKITE_TAG"
+      - ".buildkite/scripts/make_image.sh"
+
+  # Miner AMD64 testnet
+  #
+  # Does not start with "val" but does end with "_testnet"
+  - if: build.tag !~ /^val/ && build.tag =~ /_testnet\$/
+    name: ":whale: testnet AMD64 docker"
+    env:
+      BUILD_TYPE: "miner"
+      IMAGE_ARCH: "amd64"
+      REGISTRY_HOST: "quay.io"
+      REGISTRY_ORG: "team-helium"
+      REGISTRY_NAME: "testnet"
+      VERSION_TAG: $BUILDKITE_TAG
+      BUILD_NET: "testnet"
+    agents:
+      queue: "erlang"
     commands:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"

--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -53,12 +53,6 @@ case "$BUILD_TYPE" in
         BASE_DOCKER_NAME=$(basename $(pwd))
         DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
         ;;
-    "miner-testnet")
-        echo "Doing a testnet miner image build for ${IMAGE_ARCH}"
-        DOCKER_BUILD_ARGS="--build-arg EXTRA_BUILD_APK_PACKAGES=apk-tools --build-arg EXTRA_RUNNER_APK_PACKAGES=apk-tools --build-arg BUILDER_IMAGE=${BUILD_IMAGE} --build-arg RUNNER_IMAGE=${RUN_IMAGE} --build-arg REBAR_BUILD_TARGET=docker_testminer ${DOCKER_BUILD_ARGS}"
-        BASE_DOCKER_NAME=$(basename $(pwd))
-        DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_testnet_${VERSION}"
-        ;;
     *)
         echo "I don't know how to do a build for ${BUILD_TYPE}"
         exit 1


### PR DESCRIPTION
When building a non-validator tag ending with "_testnet":

- set "NET_TYPE" to "testnet"
- set image registry to quay.io/team-helium/testnet
- strip "_testnet" from the version since it's going to a different registry

## Reviewing

I pushed the tag `2022.02.09.0_PR1427_testnet`, iﬀ: 

- [x] it [build]s
- [x] gets published to [`team-helium/testnet`] 
  -  [ ] with the image name `2022.02.09.0_PR1427` (1) 
- [x] **does not** get published to [`team-helium/miner`] 

then everything worked correctly.

1: note the lack of `_testnet` in the image name

[build]: https://buildkite.com/helium/miner/builds?branch=2022.02.09.0_PR1427_testnet
[`team-helium/testnet`]: https://quay.io/repository/team-helium/testnet?tab=tags
[`team-helium/miner`]: https://quay.io/repository/team-helium/miner?tab=tags