### PR TITLE
Fixes parse_integer to throw an error

### DIFF
--- a/src/jsonrpc/miner_jsonrpc_txn.erl
+++ b/src/jsonrpc/miner_jsonrpc_txn.erl
@@ -108,5 +108,5 @@ parse_integer(Value) when is_binary(Value) ->
         binary_to_integer(Value)
     catch
         _:_ ->
-            {error, {invalid_integer, Value}}
+            throw({invalid_integer, Value})
     end.


### PR DESCRIPTION
instead of returning one since that’s what the caller would do also