### PR TITLE
Send _testnet tagged image builds to corresponding [validator,miner]-testnet Quay registries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       queue: "erlang"
 
   - if: build.tag =~ /^validator/
-    name: "validator AMD64 docker"
+    name: ":whale: validator AMD64 docker"
     env:
       BUILD_TYPE: "validator"
       IMAGE_ARCH: "amd64"
@@ -49,7 +49,7 @@ steps:
       - ".buildkite/scripts/make_image.sh"
 
   - if: build.tag =~ /^validator/
-    name: "validator ARM64 docker"
+    name: ":whale: validator ARM64 docker"
     env:
       BUILD_TYPE: "validator"
       IMAGE_ARCH: "arm64"
@@ -64,14 +64,14 @@ steps:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"
 
-  - if: build.tag =~ /^val\d/
-    name: "testnet validator AMD64 docker"
+  - if: build.tag =~ /^testnet_validator/
+    name: ":whale: testnet validator AMD64 docker"
     env:
-      BUILD_TYPE: "val"
+      BUILD_TYPE: "validator"
       IMAGE_ARCH: "amd64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_ORG: "team-helium"
-      REGISTRY_NAME: "validator"
+      REGISTRY_NAME: "validator-testnet"
       VERSION_TAG: $BUILDKITE_TAG
       BUILD_NET: "testnet"
     agents:
@@ -80,14 +80,14 @@ steps:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"
 
-  - if: build.tag =~ /^val\d/
-    name: "testnet validator ARM64 docker"
+  - if: build.tag =~ /^testnet_validator/
+    name: ":whale: testnet validator ARM64 docker"
     env:
-      BUILD_TYPE: "val"
+      BUILD_TYPE: "validator"
       IMAGE_ARCH: "arm64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_ORG: "team-helium"
-      REGISTRY_NAME: "validator"
+      REGISTRY_NAME: "validator-testnet"
       VERSION_TAG: $BUILDKITE_TAG
       BUILD_NET: "testnet"
     agents:
@@ -96,7 +96,7 @@ steps:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"
 
-  - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/ && build.tag !~ /_testnet\$/
+  - if: build.tag != null && build.tag !~ /val/ && build.tag !~ /testnet/
     name: ":whale: AMD64 docker"
     env:
       BUILD_TYPE: "miner"
@@ -112,7 +112,7 @@ steps:
       - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_image.sh"
 
-  - if: build.tag != null && build.tag !~ /^validator/ && build.tag !~ /^val\d/ && build.tag !~ /_testnet\$/
+  - if: build.tag != null && build.tag !~ /val/ && build.tag !~ /testnet/
     name: ":whale: ARM64 docker"
     agents:
       queue: "arm64"
@@ -129,10 +129,8 @@ steps:
       - ".buildkite/scripts/make_image.sh"
 
   # Miner ARM64 testnet
-  #
-  # Does not start with "val" but does end with "_testnet"
-  - if: build.tag !~ /^val/ && build.tag =~ /_testnet\$/
-    name: ":whale: testnet ARM64 docker"
+  - if: build.tag !~ /val/ && build.tag =~ /^testnet_/
+    name: ":whale: testnet miner ARM64 docker"
     agents:
       queue: "arm64"
     env:
@@ -140,7 +138,7 @@ steps:
       IMAGE_ARCH: "arm64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_ORG: "team-helium"
-      REGISTRY_NAME: "testnet"
+      REGISTRY_NAME: "miner-testnet"
       VERSION_TAG: $BUILDKITE_TAG
       BUILD_NET: "testnet"
     commands:
@@ -148,16 +146,14 @@ steps:
       - ".buildkite/scripts/make_image.sh"
 
   # Miner AMD64 testnet
-  #
-  # Does not start with "val" but does end with "_testnet"
-  - if: build.tag !~ /^val/ && build.tag =~ /_testnet\$/
-    name: ":whale: testnet AMD64 docker"
+  - if: build.tag !~ /val/ && build.tag =~ /^testnet_/
+    name: ":whale: testnet miner AMD64 docker"
     env:
       BUILD_TYPE: "miner"
       IMAGE_ARCH: "amd64"
       REGISTRY_HOST: "quay.io"
       REGISTRY_ORG: "team-helium"
-      REGISTRY_NAME: "testnet"
+      REGISTRY_NAME: "miner-testnet"
       VERSION_TAG: $BUILDKITE_TAG
       BUILD_NET: "testnet"
     agents:

--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -24,41 +24,44 @@ if [[ "$IMAGE_ARCH" == "arm64" ]]; then
     RUN_IMAGE="arm64v8/$RUN_IMAGE"
 fi
 
-VERSION=$(echo $VERSION_TAG | sed -e "s/$BUILD_TYPE//")
-DOCKER_BUILD_ARGS="--build-arg VERSION=$VERSION --build-arg BUILD_NET=$BUILD_NET"
+VERSION=$(echo $VERSION_TAG | sed "s/^${BUILD_NET}_//" | sed "s/^${BUILD_TYPE}//")
+DOCKER_BUILD_ARGS="--build-arg BUILDER_IMAGE=$BUILD_IMAGE --build-arg RUNNER_IMAGE=$RUN_IMAGE --build-arg VERSION=$VERSION --build-arg BUILD_NET=$BUILD_NET"
 
 if [[ ! $TEST_BUILD -eq "0" ]]; then
     REGISTRY_NAME="test-builds"
     DOCKER_BUILD_ARGS="--build-arg REBAR_DIAGNOSTIC=1 $DOCKER_BUILD_ARGS"
 fi
-MINER_REGISTRY_NAME="$REGISTRY_HOST/$REGISTRY_ORG/$REGISTRY_NAME"
+FULL_REGISTRY_NAME="$REGISTRY_HOST/$REGISTRY_ORG/$REGISTRY_NAME"
 
-case "$BUILD_TYPE" in
-    "val")
-        echo "Doing a testnet validator image build for ${IMAGE_ARCH}"
-        DOCKER_BUILD_ARGS="--build-arg BUILDER_IMAGE=$BUILD_IMAGE --build-arg RUNNER_IMAGE=$RUN_IMAGE --build-arg REBAR_BUILD_TARGET=docker_testval $DOCKER_BUILD_ARGS"
-        BASE_DOCKER_NAME="validator"
-        DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_testnet_${VERSION}"
-        LATEST_TAG="latest-val-${IMAGE_ARCH}"
-        ;;
-    "validator")
+case "${BUILD_TYPE}-$BUILD_NET" in
+    "validator-mainnet")
         echo "Doing a mainnet validator image build for $IMAGE_ARCH"
-        DOCKER_BUILD_ARGS="--build-arg BUILDER_IMAGE=${BUILD_IMAGE} --build-arg RUNNER_IMAGE=${RUN_IMAGE} --build-arg REBAR_BUILD_TARGET=docker_val ${DOCKER_BUILD_ARGS}"
+        DOCKER_BUILD_ARGS="--build-arg REBAR_BUILD_TARGET=docker_val $DOCKER_BUILD_ARGS"
         BASE_DOCKER_NAME="validator"
         DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
         ;;
-    "miner")
+    "validator-testnet")
+        echo "Doing a testnet validator image build for ${IMAGE_ARCH}"
+        DOCKER_BUILD_ARGS="--build-arg REBAR_BUILD_TARGET=docker_testval $DOCKER_BUILD_ARGS"
+        BASE_DOCKER_NAME="validator"
+        DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
+        ;;
+    "miner-mainnet")
         echo "Doing a miner image build for ${IMAGE_ARCH}"
-        DOCKER_BUILD_ARGS="--build-arg EXTRA_BUILD_APK_PACKAGES=apk-tools --build-arg EXTRA_RUNNER_APK_PACKAGES=apk-tools --build-arg BUILDER_IMAGE=${BUILD_IMAGE} --build-arg RUNNER_IMAGE=${RUN_IMAGE} --build-arg REBAR_BUILD_TARGET=docker ${DOCKER_BUILD_ARGS}"
+        DOCKER_BUILD_ARGS="--build-arg EXTRA_BUILD_APK_PACKAGES=apk-tools --build-arg EXTRA_RUNNER_APK_PACKAGES=apk-tools --build-arg REBAR_BUILD_TARGET=docker $DOCKER_BUILD_ARGS"
         BASE_DOCKER_NAME=$(basename $(pwd))
         DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
         ;;
-    *)
-        echo "I don't know how to do a build for ${BUILD_TYPE}"
+    "miner-testnet")
+        echo "Doing a testnet miner image build for ${IMAGE_ARCH}"
+        DOCKER_BUILD_ARGS="--build-arg EXTRA_BUILD_APK_PACKAGES=apk-tools --build-arg EXTRA_RUNNER_APK_PACKAGES=apk-tools --build-arg REBAR_BUILD_TARGET=docker_testminer $DOCKER_BUILD_ARGS"
+        BASE_DOCKER_NAME=$(basename $(pwd))
+        DOCKER_NAME="${BASE_DOCKER_NAME}-${IMAGE_ARCH}_${VERSION}"
+        ;;    *)
+        echo "I don't know how to build ${BUILD_TYPE}-$BUILD_NET"
         exit 1
         ;;
 esac
-
 
 if [[ ! $TEST_BUILD ]]; then
     docker login -u="${REGISTRY_ORG}+buildkite" -p="${QUAY_BUILDKITE_PASSWORD}" ${REGISTRY_HOST}
@@ -82,13 +85,13 @@ if [[ "$BUILD_TYPE" == "miner" ]]; then
         UPDATE_TAG="${UPDATE_TAG}-${IMAGE_ARCH}"
         SEMVER_TAG=$(echo "$DOCKER_NAME" | sed -e 's/_GA//' -e 's/_alpha//' -e 's/_beta//')
 
-        docker pull "$MINER_REGISTRY_NAME:$SEMVER_TAG"
-        docker tag "$MINER_REGISTRY_NAME:$SEMVER_TAG" "$MINER_REGISTRY_NAME:$UPDATE_TAG"
-        docker push "$MINER_REGISTRY_NAME:$UPDATE_TAG"
+        docker pull "$FULL_REGISTRY_NAME:$SEMVER_TAG"
+        docker tag "$FULL_REGISTRY_NAME:$SEMVER_TAG" "$FULL_REGISTRY_NAME:$UPDATE_TAG"
+        docker push "$FULL_REGISTRY_NAME:$UPDATE_TAG"
 
         if [[ "$VERSION_TAG" =~ _GA$ ]]; then
-            docker tag "$MINER_REGISTRY_NAME:$SEMVER_TAG" "$MINER_REGISTRY_NAME:$DOCKER_NAME"
-            docker push "$MINER_REGISTRY_NAME:$DOCKER_NAME"
+            docker tag "$FULL_REGISTRY_NAME:$SEMVER_TAG" "$FULL_REGISTRY_NAME:$DOCKER_NAME"
+            docker push "$FULL_REGISTRY_NAME:$DOCKER_NAME"
         fi
 
         exit $?
@@ -96,5 +99,11 @@ if [[ "$BUILD_TYPE" == "miner" ]]; then
 fi
 
 docker build $DOCKER_BUILD_ARGS -t "helium:${DOCKER_NAME}" .
-docker tag "helium:$DOCKER_NAME" "$MINER_REGISTRY_NAME:$DOCKER_NAME"
-docker push "$MINER_REGISTRY_NAME:$DOCKER_NAME"
+docker tag "helium:$DOCKER_NAME" "$FULL_REGISTRY_NAME:$DOCKER_NAME"
+docker push "$FULL_REGISTRY_NAME:$DOCKER_NAME"
+
+if [[ "$BUILD_NET" == "testnet" ]]; then
+    LATEST_TAG="latest-$IMAGE_ARCH"
+    docker tag "$FULL_REGISTRY_NAME:$DOCKER_NAME" "$FULL_REGISTRY_NAME:$LATEST_TAG"
+    docker push "$FULL_REGISTRY_NAME:$LATEST_TAG"
+fi

--- a/rebar.config
+++ b/rebar.config
@@ -278,7 +278,7 @@
             },
             {docker_testval, [
               {relx, [
-                {release, {miner, {semver, "val"}},
+                {release, {miner, {semver, "testnet_validator"}},
                   [miner,
                     tools,
                     runtime_tools,
@@ -294,7 +294,7 @@
             },
             {docker_testminer, [
               {relx, [
-                {release, {miner, {semver, "testminer"}},
+                {release, {miner, {semver, "testnet_"}},
                   [miner,
                     tools,
                     runtime_tools,


### PR DESCRIPTION
This PR declutters image registries by keeping testnet builds out of them. The tagging scheme is as follows:

<table><thead><tr><th>Example Tag</th><th>Registry</th></tr></thead><tbody><tr><td>2022.02.23.0</td><td>quay.io/team-helium/miner</td></tr><tr><td>testnet_2022.02.23.0</td><td>quay.io/team-helium/miner-testnet</td></tr><tr><td>validator1.8.0</td><td>quay.io/team-helium/validator</td></tr><tr><td>testnet_validator0.1.99<br></td><td>quay.io/team-helium/validator-testnet</td></tr></tbody></table>

## Remaining

- [x] rename current `quay.io/team-helium/testnet` registry to `quay.io/team-helium/miner-testnet`
- [x] create `quay.io/team-helium/validator-testnet` registry
