### PR TITLE
allows passing key config values directly to supervisors in tests

### DIFF
--- a/src/miner_keys.erl
+++ b/src/miner_keys.erl
@@ -190,7 +190,9 @@ keys({ecc, Options}) when is_list(Options) ->
                 end,
                 onboarding_key => libp2p_crypto:pubkey_to_b58(OnboardingKey)
             }
-    end.
+    end;
+keys(#{pubkey := _PubKey, ecdh_fun := _ECDH, sig_fun := _Sig} = KeyInfo) ->
+    maps:merge(#{key_slot => undefined, bus => undefined, address => undefined}, KeyInfo).
 
 -spec key_config() -> key_configuration().
 key_config() ->

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -937,7 +937,7 @@ config_node({Miner, {TCPPort, UDPPort, JSONRPCPort}, ECDH, PubKey, _Addr, SigFun
     ct_rpc:call(Miner, application, set_env, [lager, metadata_whitelist, [poc_id]]),
 
     %% set blockchain configuration
-    Key = {PubKey, ECDH, SigFun},
+    Key = #{pubkey => PubKey, ecdh_fun => ECDH, sig_fun => SigFun},
 
     MinerBaseDir = BaseDir ++ "_" ++ atom_to_list(Miner),
     ct:pal("MinerBaseDir: ~p", [MinerBaseDir]),


### PR DESCRIPTION
Many common test setups rely on explicitly pre-generating the critical ecc key details, pubkey, ecdh function and signing function, and passing them directly to the application supervisors at startup. This change allows the `miner_keys:keys/0` to accept and passthrough these test-case config overrides directly to the processes that expect them.