### PR TITLE
Validating block_size_limit enforces manageable block txn sizes

### DIFF
--- a/src/miner_hbbft_sidecar.erl
+++ b/src/miner_hbbft_sidecar.erl
@@ -358,4 +358,4 @@ oversized_txn(Txn, Ledger) ->
             {ok, SizeLimit} when is_integer(SizeLimit) -> SizeLimit;
             _ -> 50*1024*1024
         end,
-    byte_size(blockchain_txn:serialize(Txn)) =< BlockSizeLimit.
+    byte_size(blockchain_txn:serialize(Txn)) > BlockSizeLimit.

--- a/src/miner_hbbft_sidecar.erl
+++ b/src/miner_hbbft_sidecar.erl
@@ -3,6 +3,7 @@
 -behaviour(gen_server).
 
 -include_lib("blockchain/include/blockchain.hrl").
+-include_lib("blockchain/include/blockchain_vars.hrl").
 
 % API
 -export([
@@ -124,41 +125,47 @@ handle_call({submit, Txn}, From,
                    validations = Validations} = State) ->
     Type = blockchain_txn:type(Txn),
     lager:debug("got submission of txn: ~s", [blockchain_txn:print(Txn)]),
-    {ok, Height} = blockchain_ledger_v1:current_height(blockchain:ledger(Chain)),
+    Ledger = blockchain:ledger(Chain),
+    {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
     case lists:member(Type, ?InvalidTxns) of
         true ->
             {reply, {{error, invalid_txn}, Height}, State};
         false ->
-            case maps:find(Type, ?SlowTxns) of
-                {ok, Timeout} ->
-                    Limit = application:get_env(miner, sidecar_parallelism_limit, 3),
-                    case maps:size(Validations) of
-                        N when N >= Limit ->
-                            Queue1 = Queue ++ [{From, Txn, Height}],
-                            {noreply, State#state{queue = Queue1}};
-                        _ ->
-                            {Attempt, V} = start_validation(Txn, Height, From, Timeout, Chain),
-                            {noreply, State#state{validations = Validations#{Attempt => V}}}
-                    end;
-                error ->
-                    case blockchain_txn:is_valid(Txn, Chain) of
-                        ok ->
-                            case blockchain_txn:absorb(Txn, Chain) of
-                                ok ->
-                                    spawn(fun() ->
-                                                  %% this will now return {ok, Position, Length}
-                                                  %% or {error, full} which we could feed back to the caller using gen_server:reply() on the From
-                                                catch libp2p_group_relcast:handle_command(Group, {txn, Txn})
-                                        end),
-                                    {reply, {ok, Height}, State};
-                                Error ->
-                                    lager:warning("speculative absorb failed for ~s, error: ~p", [blockchain_txn:print(Txn), Error]),
-                                    {reply, {Error, Height}, State}
+            case oversized_txn(Txn, Ledger) of
+                true ->
+                    {reply, {{error, oversized_txn}, Height}, State};
+                false ->
+                    case maps:find(Type, ?SlowTxns) of
+                        {ok, Timeout} ->
+                            Limit = application:get_env(miner, sidecar_parallelism_limit, 3),
+                            case maps:size(Validations) of
+                                N when N >= Limit ->
+                                    Queue1 = Queue ++ [{From, Txn, Height}],
+                                    {noreply, State#state{queue = Queue1}};
+                                _ ->
+                                    {Attempt, V} = start_validation(Txn, Height, From, Timeout, Chain),
+                                    {noreply, State#state{validations = Validations#{Attempt => V}}}
                             end;
-                        Error ->
-                            write_txn("failed", Height, Txn),
-                            lager:debug("is_valid failed for ~s, error: ~p", [blockchain_txn:print(Txn), Error]),
-                            {reply, {Error, Height}, State}
+                        error ->
+                            case blockchain_txn:is_valid(Txn, Chain) of
+                                ok ->
+                                    case blockchain_txn:absorb(Txn, Chain) of
+                                        ok ->
+                                            spawn(fun() ->
+                                                      %% this will now return {ok, Position, Length}
+                                                      %% or {error, full} which we could feed back to the caller using gen_server:reply() on the From
+                                                      catch libp2p_group_relcast:handle_command(Group, {txn, Txn})
+                                                  end),
+                                            {reply, {ok, Height}, State};
+                                        Error ->
+                                            lager:warning("speculative absorb failed for ~s, error: ~p", [blockchain_txn:print(Txn), Error]),
+                                            {reply, {Error, Height}, State}
+                                    end;
+                                Error ->
+                                    write_txn("failed", Height, Txn),
+                                    lager:debug("is_valid failed for ~s, error: ~p", [blockchain_txn:print(Txn), Error]),
+                                    {reply, {Error, Height}, State}
+                            end
                     end
             end
     end;
@@ -344,3 +351,11 @@ start_validation(Txn, Height, From, Timeout, Chain) ->
     TRef = erlang:send_after(Timeout, self(), {Attempt, {{error, validation_deadline}, Height}}),
     {Attempt,
      #validation{timer = TRef, monitor = Ref, txn = Txn, pid = Pid, from = From, height=Height}}.
+
+oversized_txn(Txn, Ledger) ->
+    BlockSizeLimit =
+        case blockchain:config(?block_size_limit, Ledger) of
+            {ok, SizeLimit} when is_integer(SizeLimit) -> SizeLimit;
+            _ -> 50*1024*1024
+        end,
+    byte_size(blockchain_txn:serialize(Txn)) =< BlockSizeLimit.

--- a/src/miner_keys.erl
+++ b/src/miner_keys.erl
@@ -190,7 +190,9 @@ keys({ecc, Options}) when is_list(Options) ->
                 end,
                 onboarding_key => libp2p_crypto:pubkey_to_b58(OnboardingKey)
             }
-    end.
+    end;
+keys(#{pubkey := _PubKey, ecdh_fun := _ECDH, sig_fun := _Sig} = KeyInfo) ->
+    maps:merge(#{key_slot => undefined, bus => undefined, address => undefined}, KeyInfo).
 
 -spec key_config() -> key_configuration().
 key_config() ->

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -937,7 +937,7 @@ config_node({Miner, {TCPPort, UDPPort, JSONRPCPort}, ECDH, PubKey, _Addr, SigFun
     ct_rpc:call(Miner, application, set_env, [lager, metadata_whitelist, [poc_id]]),
 
     %% set blockchain configuration
-    Key = {PubKey, ECDH, SigFun},
+    Key = #{pubkey => PubKey, ecdh_fun => ECDH, sig_fun => SigFun},
 
     MinerBaseDir = BaseDir ++ "_" ++ atom_to_list(Miner),
     ct:pal("MinerBaseDir: ~p", [MinerBaseDir]),

--- a/test/miner_txn_mgr_SUITE.erl
+++ b/test/miner_txn_mgr_SUITE.erl
@@ -116,11 +116,11 @@ txn_in_sequence_nonce_test(Config) ->
     PayerAddr = Addr,
     Payee = hd(miner_ct_utils:shuffle(ConMiners)),
     PayeeAddr = miner_ct_utils:node2addr(Payee, AddrList),
-    {ok, _Pubkey, SigFun, _ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
+    {ok, Pubkey, SigFun, ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
 
     StartNonce = miner_ct_utils:get_nonce(Miner, Addr),
 
-    {ok, _Pubkey, SigFun, _ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
+    {ok, Pubkey, SigFun, ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
 
     %% the first txn
     Txn1 = ct_rpc:call(Miner, blockchain_txn_payment_v1, new, [PayerAddr, PayeeAddr, 1000, StartNonce+1]),
@@ -165,10 +165,10 @@ txn_out_of_sequence_nonce_test(Config) ->
     PayerAddr = Addr,
     Payee = hd(miner_ct_utils:shuffle(ConMiners)),
     PayeeAddr = miner_ct_utils:node2addr(Payee, AddrList),
-    {ok, _Pubkey, SigFun, _ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
+    {ok, Pubkey, SigFun, ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
 
     StartNonce = miner_ct_utils:get_nonce(Miner, Addr),
-    {ok, _Pubkey, SigFun, _ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
+    {ok, Pubkey, SigFun, ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
 
     %% the first txn
     Txn1 = ct_rpc:call(Miner, blockchain_txn_payment_v1, new, [PayerAddr, PayeeAddr, 1000, StartNonce+1]),
@@ -235,10 +235,10 @@ txn_invalid_nonce_test(Config) ->
     PayerAddr = Addr,
     Payee = hd(miner_ct_utils:shuffle(ConMiners)),
     PayeeAddr = miner_ct_utils:node2addr(Payee, AddrList),
-    {ok, _Pubkey, SigFun, _ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
+    {ok, Pubkey, SigFun, ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
 
     StartNonce = miner_ct_utils:get_nonce(Miner, Addr),
-    {ok, _Pubkey, SigFun, _ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
+    {ok, Pubkey, SigFun, ECDHFun} = ct_rpc:call(Miner, blockchain_swarm, keys, []),
 
     %% the first txn
     Txn1 = ct_rpc:call(Miner, blockchain_txn_payment_v1, new, [PayerAddr, PayeeAddr, 1000, StartNonce+1]),


### PR DESCRIPTION
PaymentV2 testing additions validate that enforcing a block_size_limit chain variable drops the byte_size of serialized txns and txns continue to flow into subsequent blocks when they are not able to fit into a block.

Also validates and enforces that txns that are too big to ever be serialized to a size that will fit within the given limit are rejected in the hbbft_sidecar process submitting txns to the consensus group so they don't clog up the submission queue.