### PR TITLE
Set relx rpc timeout to 900 seconds

### DIFF
--- a/scripts/extensions/authorize
+++ b/scripts/extensions/authorize
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"authorize\","

--- a/scripts/extensions/dkg
+++ b/scripts/extensions/dkg
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"dkg\","

--- a/scripts/extensions/genesis
+++ b/scripts/extensions/genesis
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"genesis\","

--- a/scripts/extensions/hbbft
+++ b/scripts/extensions/hbbft
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"hbbft\","

--- a/scripts/extensions/info
+++ b/scripts/extensions/info
@@ -4,6 +4,8 @@ if [ -t 0 ] ; then
     export CLIQUE_COLUMNS
 fi
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 j=1
 l=$#
 buf="[[\"info\","

--- a/scripts/extensions/print_keys
+++ b/scripts/extensions/print_keys
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
 CONFIG=$(find $ROOTDIR/releases -name sys.config)
 LIB_DIR=$ROOTDIR/lib
 


### PR DESCRIPTION
Problem to solve: We are tired of getting relx timeout errors from the command line.

Solution: Set the timeout value to something really big.

(See also https://github.com/helium/blockchain-core/pull/1268)