### PR TITLE
monitoring and testing gateway grpc pid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ endif
 
 GRPC_SERVICES_DIR=src/grpc/autogen
 
-GATEWAY_RS_VSN ?= main
-SEMTECH_UDP_VSN ?= master
+GATEWAY_RS_VSN ?= "v1.0.0-alpha.23"
+SEMTECH_UDP_VSN ?= "v0.8.0"
 
 all: compile
 

--- a/src/miner_gateway_port.erl
+++ b/src/miner_gateway_port.erl
@@ -76,7 +76,7 @@ terminate(_, State) ->
     ok = cleanup_port(State).
 
 open_gateway_port(KeyPair, Transport, Host, TcpPort) ->
-    Args = ["-c", gateway_config_dir(), "server"],
+    Args = ["-c", gateway_config_dir(), "--stdin", "server"],
     GatewayEnv0 = [{"GW_API", erlang:integer_to_list(TcpPort)}, {"GW_KEYPAIR", KeyPair}],
     GatewayEnv =
         case application:get_env(miner, gateway_env) of


### PR DESCRIPTION
The http_connection pid started by the grpc_client library is currently not monitored in any way by the gateway ecc worker process beyond including it in the connection record returned when establishing the connection. In the event the process exits, the ecc worker has no indication that its connection is gone and all subsequent attempts to establish a connection stream will fail.

This change monitors the connection process and attempts to clean up the remainder of the old connection before reconnecting as soon as the old pid is lost.

This change also adds the new `--stdin` flag expected by the latest release of the embedded gateway-rs.