### PR TITLE
Consolidate udp listener port config under radio_device

### DIFF
--- a/config/docker.config
+++ b/config/docker.config
@@ -13,8 +13,8 @@
     [
      {gateway_and_mux_enable, false},
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
-     {radio_device, { {0,0,0,0}, 1680, %% change to 1681 when activating mux+gateway-rs
-        {0,0,0,0}, 31341} },
+     {radio_device, { {0,0,0,0}, 1680,
+                      {0,0,0,0}, 31341} },
      {use_ebus, false}
     ]}
 ].

--- a/config/sys.config
+++ b/config/sys.config
@@ -110,7 +110,7 @@
    {update_dir, "/opt/miner/update"},
    {api_base_url, "https://api.helium.io/v1"},
    {election_interval, 30},
-   {radio_device, { {127,0,0,1}, 1680, %% change to 1681 when activating mux+gateway-rs
+   {radio_device, { {127,0,0,1}, 1680,
                     {127,0,0,1}, 31341} },
    {default_routers, ["/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa","/p2p/11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY"]},
    {mark_mods, [miner_hbbft_handler]},

--- a/priv/gateway_rs/settings.toml
+++ b/priv/gateway_rs/settings.toml
@@ -1,6 +1,3 @@
-## semtech listening address override
-listen = "127.0.0.1:1682"
-
 ## api listening port override
 api = 4468
 

--- a/src/miner_gateway_ecc_worker.erl
+++ b/src/miner_gateway_ecc_worker.erl
@@ -68,8 +68,8 @@ start_link(Options) when is_list(Options) ->
 
 init([Options]) ->
     Transport = proplists:get_value(transport, Options, tcp),
-    Host = proplists:get_value(host, Options, "localhost"),
-    Port = proplists:get_value(port, Options, 4468),
+    Host = proplists:get_value(host, Options, "127.0.0.1"),
+    Port = proplists:get_value(api_port, Options, 4468),
     {ok, #{http_connection := ConnPid} = Connection} = grpc_connect(Transport, Host, Port),
     MonRef = erlang:monitor(process, ConnPid),
     {ok, #state{

--- a/src/miner_restart_sup.erl
+++ b/src/miner_restart_sup.erl
@@ -62,7 +62,12 @@ init(_Opts) ->
 
     OnionServer =
         case application:get_env(miner, radio_device, undefined) of
-            {RadioBindIP, RadioBindPort, RadioSendIP, RadioSendPort} ->
+            {RadioBindIP, RadioBindPort0, RadioSendIP, RadioSendPort} ->
+                RadioBindPort =
+                    case application:get_env(miner, gateway_and_mux_enable, false) of
+                        false -> RadioBindPort0;
+                        true -> RadioBindPort0 + 1
+                    end,
                 %% check if we are overriding/forcing the region ( for lora )
                 RegionOverRide = check_for_region_override(),
                 OnionOpts = #{

--- a/test/miner_gateway_mux_integration_SUITE.erl
+++ b/test/miner_gateway_mux_integration_SUITE.erl
@@ -18,7 +18,7 @@ all() ->
 init_per_suite(Config) ->
     ok = application:load(miner),
     ok = application:set_env(miner, gateway_and_mux_enable, true),
-    ok = application:set_env(miner, radio_device, {{127, 0, 0, 1}, 1681, {127, 0, 0, 1}, 31341}),
+    ok = application:set_env(miner, radio_device, {{127, 0, 0, 1}, 1680, deprecated, deprecated}),
     application:ensure_all_started(miner),
     Config.
 


### PR DESCRIPTION
Makes it easier for drop-in replacement and update of settings (such as moving from mainnet to testnet or vice versa) by reducing the number of sys.config changes needed to configure the different settings and process trees within the miner.

By consolidating all of the possible variations of a UDP listener to derive their configuration from the existing `miner, radio_device` application env key, the "public interface" for configuring the miner's listener remains the same.