### PR TITLE
passing tpm key_path to worker; ensuring started

### DIFF
--- a/src/miner_critical_sup.erl
+++ b/src/miner_critical_sup.erl
@@ -105,6 +105,12 @@ init(_Opts) ->
                           %% Miner retains full control and responsibility for key access
                           ?WORKER(miner_ecc_worker, [KeySlot, Bus, Address])
                          ] ++ ChildSpecs0;
+                     {false, {ok, {tpm, _}}} ->
+                         [
+                          %% Miner still retains full control and responsibility for key access;
+                          %% this time in the tpm worker
+                          ?WORKER(miner_tpm_worker, [KeySlot])
+                         ] ++ ChildSpecs0;
                      _ ->
                          ChildSpecs0
                  end,

--- a/src/miner_keys.erl
+++ b/src/miner_keys.erl
@@ -221,16 +221,18 @@ keys({tpm, Props}) when is_list(Props) ->
     end,
 
     #{ pubkey => PubKey,
-        key_path => KeyPath,
-        ecdh_fun => fun(PublicKey) ->
-            {ok, [X, Y]} = miner_tpm_worker:ecdh(PublicKey),
-            <<X/binary>>
-                    end,
-        sig_fun => fun(Bin) ->
-            {ok, {Sig, _PublicKey,_Cert}} = miner_tpm_worker:sign(Bin),
-            Sig
+       bus => undefined,
+       address => undefined,
+       key_slot => KeyPath,
+       ecdh_fun => fun(PublicKey) ->
+                       {ok, [X, Y]} = miner_tpm_worker:ecdh(PublicKey),
+                       <<X/binary>>
                    end,
-        onboarding_key => libp2p_crypto:pubkey_to_b58(PubKey)
+       sig_fun => fun(Bin) ->
+                      {ok, {Sig, _PublicKey,_Cert}} = miner_tpm_worker:sign(Bin),
+                      Sig
+                  end,
+       onboarding_key => libp2p_crypto:pubkey_to_b58(PubKey)
     };
 keys(#{pubkey := _PubKey, ecdh_fun := _ECDH, sig_fun := _Sig} = KeyInfo) ->
     maps:merge(#{key_slot => undefined, bus => undefined, address => undefined}, KeyInfo).


### PR DESCRIPTION
minor changes to make the tpm branch configuration compliant with the current process supervision tree/startup where the `miner_critical_sup` is defining and starting erlang-based crypto signing workers if the embedded gateway is _not_ enabled (`miner_ecc_worker` and `miner_tpm_worker`) and ensuring the return value of `miner_keys:keys/0` matches what the critical supervisor needs to start the worker correctly.