### PR TITLE
Fix format error.

### DIFF
--- a/src/poc/miner_poc_denylist.erl
+++ b/src/poc/miner_poc_denylist.erl
@@ -106,7 +106,7 @@ handle_info(check, #state{type=github_release, url=URL, keys=Keys, version=Versi
                             lager:notice("denylist version has regressed from ~s to ~s, ignoring", [Version, NewVersion]),
                             {noreply, schedule_check(State#state{etag=proplists:get_value("etag", Headers)})};
                         NewVersion when NewVersion > Version ->
-                            lager:info("new denylist version appeared: ~s have ~s", [NewVersion, Version]),
+                            lager:info("new denylist version appeared: ~p have ~p", [NewVersion, Version]),
                             case maps:get(<<"assets">>, Json, undefined) of
                                 undefined ->
                                     lager:notice("no zipball_url for release ~p", [NewVersion]),

--- a/src/poc/miner_poc_denylist.erl
+++ b/src/poc/miner_poc_denylist.erl
@@ -103,7 +103,7 @@ handle_info(check, #state{type=github_release, url=URL, keys=Keys, version=Versi
                             lager:info("already have version ~p", [Version]),
                             {noreply, schedule_check(State#state{etag=proplists:get_value("etag", Headers)})};
                         NewVersion when NewVersion < Version->
-                            lager:notice("denylist version has regressed from ~s to ~s, ignoring", [Version, NewVersion]),
+                            lager:notice("denylist version has regressed from ~p to ~p, ignoring", [Version, NewVersion]),
                             {noreply, schedule_check(State#state{etag=proplists:get_value("etag", Headers)})};
                         NewVersion when NewVersion > Version ->
                             lager:info("new denylist version appeared: ~p have ~p", [NewVersion, Version]),


### PR DESCRIPTION
Bug proof in this log line:

```
2022-03-15 02:28:31.311 1 [info] <0.1844.0>@miner_poc_denylist:handle_info:{109,29} FORMAT ERROR: "new denylist version appeared: ~s have ~s" [2022031101,0]
```

Terms are integers, not strings.