### PR TITLE
default disable embedded rust gateway and mux

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -31,7 +31,6 @@
    %% we only realy need the params below if this file is changed to specify a radio device
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
-   {region_override, 'US915'},
-   {gateway_and_mux_enable, false}
+   {region_override, 'US915'}
   ]}
 ].

--- a/config/docker-testnet.config
+++ b/config/docker-testnet.config
@@ -23,7 +23,7 @@
      {network, testnet},
      {api_base_url, "https://testnet-api.helium.wtf/v1"},
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
-     {gateway_and_mux_enable, false},
+     {gateway_and_mux_enable, true},
      {use_ebus, false},
       {radio_device, { {0,0,0,0}, 1680,
         {0,0,0,0}, 31341} }

--- a/config/docker-testval.config.src
+++ b/config/docker-testval.config.src
@@ -51,7 +51,6 @@
    %% we only realy need the params below if this file is changed to specify a radio device
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
-   {region_override, 'US915'},
-   {gateway_and_mux_enable, false}
+   {region_override, 'US915'}
   ]}
 ].

--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -48,7 +48,6 @@
    %% we only realy need the params below if this file is changed to specify a radio device
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
-   {region_override, 'US915'},
-   {gateway_and_mux_enable, false}
+   {region_override, 'US915'}
   ]}
 ].

--- a/config/docker.config
+++ b/config/docker.config
@@ -11,7 +11,6 @@
     ]},
   {miner,
     [
-     {gateway_and_mux_enable, false},
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
      {radio_device, { {0,0,0,0}, 1680,
                       {0,0,0,0}, 31341} },

--- a/config/seed.config
+++ b/config/seed.config
@@ -31,7 +31,6 @@
    {block_time, 1000},
    {election_interval, 15},
    {dkg_stop_timeout, 15000},
-   {radio_device, undefined},
-   {gateway_and_mux_enable, false}
+   {radio_device, undefined}
   ]}
 ].

--- a/config/sys.config
+++ b/config/sys.config
@@ -101,6 +101,7 @@
    {jsonrpc_ip, {127,0,0,1}}, %% bind JSONRPC to localhost only
    {jsonrpc_port, 4467},
    {mode, gateway},
+   {gateway_and_mux_enable, false},
    {use_ebus, true},
    {batch_size, 2500},
    {curve, 'SS512'},

--- a/config/test_val.config.src
+++ b/config/test_val.config.src
@@ -51,7 +51,6 @@
    %% we only realy need the params below if this file is changed to specify a radio device
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
-   {region_override, 'US915'},
-   {gateway_and_mux_enable, false}
+   {region_override, 'US915'}
   ]}
 ].

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -48,7 +48,6 @@
    %% we only realy need the params below if this file is changed to specify a radio device
    %% as without one miner_lora is not started
    %% including the params anyway in case someone needs it in this env
-   {region_override, 'US915'},
-   {gateway_and_mux_enable, false}
+   {region_override, 'US915'}
   ]}
 ].


### PR DESCRIPTION
move the config that disables the embedded rust gateway and udp multiplexer back to the default sysconfig file. this has two advantages:
1. cleaner config; no longer needed to disable explicitly on all other profiles when it is enabled or undefined in the base config
2. allow enabling the config for specific release profiles so it does not need to be overridden _again_ at the firmware level (but still can be as needed)

This is needed most immediately to enable easier configuration of hotspots on the testnet where the bulk of testing the latest grpc-based communication between the components of the network will be taking place