### PR TITLE
Change docker to use debian as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN apt update \
        wget \
        ${EXTRA_BUILD_APT_PACKAGES} 
 
+# Strip debug symbols from ERTS binarys to reduce size
+RUN scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local/lib/erlang | xargs -r strip --strip-unneeded
+
 # Install Rust toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
This PR updates the Dockerfile to use Debian and the associated deb package dependencies as the base image. In my testing, the validator docker image performs better when build on Debian as a base image as compared to the existing image based on Alpine. My hypothesis that the optimizations for small size and security within Alpine (and the MUSL C library it uses) result in poorer performance that the glibc based Debian.

For example, I see absorb and commit times that are on the order of 25% faster when running both the Helium Alpine image and on build with this Debian based Dockerfile on the same bare metal 6c/12t Ryzen 5 machine.

Open items:
- [x] Test with hotspot miner build
- [x] Test on ARM
- [x] See if ERTS can be reduced in size - it is significantly larger in the Erlang Debian image as compared to the Alpine one

I have also posted an image built with this Dockerfile for others to use if they wish. It is available here: `ghcr.io/paulvmo/helium-validator:1.8.3` or  `ghcr.io/paulvmo/helium-validator:latest`