### PR TITLE
Output rebar diagnostics; retry on rebar fails

### DIFF
--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 VERSION=$(echo $VERSION_TAG | sed -e 's,validator,,')
-./rebar3 as validator release -n miner -v ${VERSION}
+DIAGNOSTIC=1 ./rebar3 as validator release -n miner -v ${VERSION} || ./rebar3 as validator release -n miner -v ${VERSION}
 
 fpm -n validator \
     -v "${VERSION}" \


### PR DESCRIPTION
Problem to solve: An .app file is missing during builds sometimes and this causes rebar3 to fail, which causes a build failure which isn't easily recoverable in the context of buildkite.

Solution: Enable rebar diagnostics during debian builds; handle rebar3 failure and allow retries at a build