### PR TITLE
strip mux timestamps to parse logs

### DIFF
--- a/src/miner_mux_port.erl
+++ b/src/miner_mux_port.erl
@@ -69,7 +69,7 @@ terminate(_, State) ->
 open_mux_port(HostTcpPort, ClientTcpPorts) when is_list(ClientTcpPorts) ->
     ClientList = client_address_list(ClientTcpPorts),
     lager:info("client list ~p", [ClientList]),
-    Args = ["--host", erlang:integer_to_list(HostTcpPort)] ++ ClientList,
+    Args = ["--disable-timestamp", "--host", erlang:integer_to_list(HostTcpPort)] ++ ClientList,
     lager:info("mux args list ~p", [Args]),
     PortOpts = [
         binary,


### PR DESCRIPTION
When starting the semtech mux, in order to properly parse logs messages passed back over stdout from the port we need to strip the timestamps generated by the mux to pattern match the log level and dispatch accordingly.