### PR TITLE
don't loop forever trying to reconnect to gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,8 @@ external/
 src/grpc/
 
 # gateway-rs generated files
-gateway_key.bin
 default.toml
 helium_gateway
 
-# semtech-udp generated files
+# gwmp-mux generated files
 gwmp-mux

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 GRPC_SERVICES_DIR=src/grpc/autogen
 
 GATEWAY_RS_VSN ?= "v1.0.0-alpha.23"
-SEMTECH_UDP_VSN ?= "v0.9.2"
+GWMP_MUX_VSN ?= "v0.9.3"
 
 all: compile
 
@@ -90,18 +90,18 @@ external_svcs:
 	$(call install_rust_bin,gateway-rs,helium_gateway,gateway_rs)
 	@cp ./external/gateway-rs/config/default.toml ./priv/gateway_rs/default.toml
 
-	@echo "--- semtech-udp ---"
-	$(call clone_project,semtech-udp,$(SEMTECH_UDP_VSN))
-	@(cd ./external/semtech-udp && cargo build --release --features client\,server --example gwmp-mux)
-	$(call install_rust_bin,semtech-udp,examples/gwmp-mux,semtech_udp)
+	@echo "--- gwmp-mux ---"
+	$(call clone_project,gwmp-mux,$(GWMP_MUX_VSN))
+	@(cd ./external/gwmp-mux && cargo build --release)
+	$(call install_rust_bin,gwmp-mux,gwmp-mux,gwmp_mux)
 
 clean_external_svcs:
 	@echo "removing external dependency project files"
 	$(call remove,./external/gateway-rs)
 	$(call remove,./priv/gateway_rs/helium_gateway)
 	$(call remove,./priv/gateway_rs/default.toml)
-	$(call remove,./external/semtech-udp)
-	$(call remove,./priv/semtech_udp/gwmp-mux)
+	$(call remove,./external/gwmp-mux)
+	$(call remove,./priv/gwmp_mux/gwmp-mux)
 
 define clone_project
 	@git clone --quiet --depth 1 --branch $(2) https://github.com/helium/$(1) ./external/$(1) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 GRPC_SERVICES_DIR=src/grpc/autogen
 
 GATEWAY_RS_VSN ?= "v1.0.0-alpha.23"
-GWMP_MUX_VSN ?= "v0.9.3"
+GWMP_MUX_VSN ?= "v0.9.4"
 
 all: compile
 

--- a/src/miner_mux_port.erl
+++ b/src/miner_mux_port.erl
@@ -69,7 +69,7 @@ terminate(_, State) ->
 open_mux_port(HostTcpPort, ClientTcpPorts) when is_list(ClientTcpPorts) ->
     ClientList = client_address_list(ClientTcpPorts),
     lager:info("client list ~p", [ClientList]),
-    Args = ["--host", erlang:integer_to_list(HostTcpPort)] ++ ClientList,
+    Args = ["--disable-timestamp", "--host", erlang:integer_to_list(HostTcpPort)] ++ ClientList,
     lager:info("mux args list ~p", [Args]),
     PortOpts = [
         binary,

--- a/src/miner_mux_port.erl
+++ b/src/miner_mux_port.erl
@@ -98,7 +98,7 @@ cleanup_port(#state{port = Port} = State) ->
     ok.
 
 mux_bin() ->
-    code:priv_dir(miner) ++ "/semtech_udp/gwmp-mux".
+    code:priv_dir(miner) ++ "/gwmp_mux/gwmp-mux".
 
 client_address_list(ClientTcpPorts) when is_list(ClientTcpPorts) ->
     lists:flatmap(
@@ -111,14 +111,14 @@ client_address_list(ClientTcpPorts) when is_list(ClientTcpPorts) ->
 dispatch_port_logs(Line) ->
     case Line of
         <<" TRACE ", Statement/binary>> ->
-            lager:debug("[ semtech-udp ] ~s", [Statement]);
+            lager:debug("[ gwmp-mux ] ~s", [Statement]);
         <<" DEBUG ", Statement/binary>> ->
-            lager:debug("[ semtech-udp ] ~s", [Statement]);
+            lager:debug("[ gwmp-mux ] ~s", [Statement]);
         <<" INFO ", Statement/binary>> ->
-            lager:info("[ semtech-udp ] ~s", [Statement]);
+            lager:info("[ gwmp-mux ] ~s", [Statement]);
         <<" WARN ", Statement/binary>> ->
-            lager:warning("[ semtech-udp ] ~s", [Statement]);
+            lager:warning("[ gwmp-mux ] ~s", [Statement]);
         <<" ERROR ", Statement/binary>> ->
-            lager:error("[ semtech-udp ] ~s", [Statement]);
+            lager:error("[ gwmp-mux ] ~s", [Statement]);
         _ -> lager:debug("unhandled info ~p", [Line])
     end.


### PR DESCRIPTION
There is currently a situation where the rust gateway could crash after reconnect but before the managing port has exited the reconnect function so it never receives the next `'DOWN'` message. In this case, the port should attempt to reconnect a number of times and then return an error, which should result in the process crashing and being restarted, which should clear the (likely) transient problem preventing restart of the gateway.