### PR TITLE
sort v2 receipts as with v1 receipts

### DIFF
--- a/src/handlers/miner_hbbft_handler.erl
+++ b/src/handlers/miner_hbbft_handler.erl
@@ -246,14 +246,16 @@ handle_command({txn, Txn}, State=#state{hbbft=HBBFT}) ->
             %% sort non poc transactions first
             Comparator = case blockchain_txn:type(Txn) of
                              X when X == blockchain_txn_poc_request_v1 orelse
-                                    X == blockchain_txn_poc_receipts_v1 ->
+                                    X == blockchain_txn_poc_receipts_v1 orelse
+                                    X == blockchain_txn_poc_receipts_v2 ->
                                  fun(_) -> true end;
                              _ ->
                                  fun(OtherSerializedTxn) ->
                                         OtherTxn = blockchain_txn:deserialize(OtherSerializedTxn),
                                         case blockchain_txn:type(OtherTxn) of
                                             X when X == blockchain_txn_poc_request_v1 orelse
-                                                   X == blockchain_txn_poc_receipts_v1 ->
+                                                   X == blockchain_txn_poc_receipts_v1 orelse
+                                                   X == blockchain_txn_poc_receipts_v2 ->
                                                 false;
                                             _ ->
                                                 true


### PR DESCRIPTION
i noticed this during general review that the relatively recent shift to sort PoC txns down-list in priority was not going to hold when poc_receipts_v2 became the normal for the network after the shift to poc-over-grpc. this small change should continue the sorting of txns fee buffer as adopted in https://github.com/helium/miner/pull/1399.