### PR TITLE
move gateway config concat to before release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,12 +47,12 @@ ARG TAR_PATH=_build/$REBAR_BUILD_TARGET/rel/*/*.tar.gz
 # Now add our code
 COPY . .
 
+RUN cat ./priv/gateway_rs/${BUILD_NET}.settings >> ./priv/gateway_rs/settings.toml
 RUN ./rebar3 as ${REBAR_BUILD_TARGET} tar -n miner -v ${VERSION}
 
 RUN mkdir -p /opt/docker/update
 RUN tar -zxvf ${TAR_PATH} -C /opt/docker
 RUN wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/genesis.${BUILD_NET}
-RUN cat ./priv/gateway_rs/${BUILD_NET}.settings >> ./priv/gateway_rs/settings.toml
 
 FROM ${RUNNER_IMAGE} as runner
 


### PR DESCRIPTION
the settings.toml file for the embedded rust gateway needs to be modified for the build network prior to taring up the release so it's copied into the correct directory when the final release is unpacked and then copied over to the runtime container image. in the previous version of this feature, we were modifying the file after the release had been packaged so by the time the settings config was concatenated together that gateway_rs priv directory in `/usr/src/miner` was being ignored by subsequent operations