### PR TITLE
Disable nat on seeds and validators

### DIFF
--- a/config/seed.config
+++ b/config/seed.config
@@ -16,6 +16,7 @@
    {max_inbound_connections, 4000},
    {outbound_gossip_connections, 2},
    {peerbook_update_interval, 60000},
+   {enable_nat, false},
    {gossip_width, 600},
    {relay_limit, 100}
   ]},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -21,6 +21,7 @@
    {snapshot_memory_limit, 4096},
    {key, undefined},
    {relay_limit, 100},
+   {enable_nat, false},
    {blocks_to_protect_from_gc, 100000},
    {base_dir, "data"}
   ]},


### PR DESCRIPTION
By default NAT is enabled. For seed nodes and validators this should not be necessary.  The docker validator configuration still leaves NAT enabled though. (Should it be disabled there?)