### PR TITLE
Fix format error.

### DIFF
--- a/src/poc/miner_onion_server_light.erl
+++ b/src/poc/miner_onion_server_light.erl
@@ -306,7 +306,7 @@ decrypt(Type, IV, OnionCompactKey, Tag, CipherText, RSSI, SNR, Frequency, Channe
             end,
             State;
         {error, Reason} ->
-            lager:info([{poc_id, POCID}], "could not decrypt packet received via ~p: Reason, discarding", [Type, Reason]),
+            lager:info([{poc_id, POCID}], "could not decrypt packet received via ~p: Reason: ~p, discarding", [Type, Reason]),
             State
     end,
     NewState.


### PR DESCRIPTION
Found in logs on a _testnet_ miner that had received a _mainnet_ PoC beacon:
```
2022-04-19 00:49:02.989 1 [info] <0.1886.0>@miner_onion_server_light:decrypt:{309,13} FORMAT ERROR: "could not decrypt packet received via ~p: Reason, discarding" [radio,{error,{bad_network,0}}]
```