### PR TITLE
Use env vars for common validator configs

### DIFF
--- a/config/test_val.config.src
+++ b/config/test_val.config.src
@@ -3,7 +3,7 @@
  "config/sys.config",
  {lager,
   [
-   {log_root, "log"},
+   {log_root, "${LOG_ROOT:-log}"},
    {handlers,
     [
      {lager_file_backend, [{file, "console.log"}, {size, 52428800}, {level, info}]},
@@ -14,7 +14,7 @@
   [
    {seed_nodes, "/ip4/54.244.119.55/tcp/2154,/ip4/3.22.146.211/tcp/443"},
    {seed_node_dns, ""},
-   {listen_addresses, ["/ip4/0.0.0.0/tcp/2154"]},
+   {listen_addresses, ["${LISTEN_ADDRESS:-/ip4/0.0.0.0/tcp/2154}"]},
    {honor_quick_sync, false},
    {quick_sync_mode, assumed_valid},
    {key, undefined},
@@ -25,7 +25,7 @@
    {snapshot_memory_limit, 300},
    {relay_limit, 100},
    {blocks_to_protect_from_gc, 100000},
-   {base_dir, "data"}
+   {base_dir, "${BASE_DIR:-data}"}
   ]},
  {libp2p,
   [
@@ -48,6 +48,11 @@
    {network, testnet},
    {rocksdb_cache_size, 32},
    {rocksdb_write_buffer_size, 32},
+   {jsonrpc_ip, {${JSONRPC_IP:-127,0,0,1}}},
+   {jsonrpc_port, ${JSONRPC_PORT:-4467}},
+   {sidecar_parallelism_limit, ${SIDECAR_PARALLELISM_LIMIT:-3}},
+   {hotfix_dir, "${HOTFIX_DIR:-/opt/miner/hotfix}"},
+   {update_dir, "${UPDATE_DIR:-/opt/miner/update}"},
    %% these two now disable all the poc stuff
    {use_ebus, false},
    {radio_device, undefined},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -3,7 +3,7 @@
  "config/sys.config",
  {lager,
   [
-   {log_root, "log"},
+   {log_root, "${LOG_ROOT:-log}"},
    {handlers,
     [
      {lager_file_backend, [{file, "console.log"}, {size, 52428800}, {level, info}]},
@@ -12,7 +12,7 @@
   ]},
  {blockchain,
   [
-   {listen_addresses, ["/ip4/0.0.0.0/tcp/2154"]},
+   {listen_addresses, ["${LISTEN_ADDRESS:-/ip4/0.0.0.0/tcp/2154}"]},
    {fetch_latest_from_snap_source, false},
    {block_sync_batch_size, 10},
    {block_sync_batch_limit, 100},
@@ -22,7 +22,7 @@
    {key, undefined},
    {relay_limit, 100},
    {blocks_to_protect_from_gc, 100000},
-   {base_dir, "data"}
+   {base_dir, "${BASE_DIR:-data}"}
   ]},
  {libp2p,
   [
@@ -45,6 +45,11 @@
    {mode, validator},
    {rocksdb_cache_size, 32},
    {rocksdb_write_buffer_size, 32},
+   {jsonrpc_ip, {${JSONRPC_IP:-127,0,0,1}}},
+   {jsonrpc_port, ${JSONRPC_PORT:-4467}},
+   {sidecar_parallelism_limit, ${SIDECAR_PARALLELISM_LIMIT:-3}},
+   {hotfix_dir, "${HOTFIX_DIR:-/opt/miner/hotfix}"},
+   {update_dir, "${UPDATE_DIR:-/opt/miner/update}"},
    %% these two now disable all the poc stuff
    {use_ebus, false},
    {radio_device, undefined},


### PR DESCRIPTION
This PR adds environment variable replacement for additional configuration options commonly used by validator operators. 

As an added bonus, these templated vars will enable the elimination of the docker-specific sys.config.src templates. The docker differences that required separate sys.config.src files can be achieve using the with additional environment variables set in the image via the Dockerfile. I left that change for a separate PR.

A couple notes:
- Relx environment variable replacement drops double quotes (`"`) in strings, so I had to limit the replacement of `listen_addresses` to a single address instead of allow a list of addresses.
- I had to use an unconventional format for the `jsonrpc_ip` environment since curly brackets are a special character used by the replacement functionality. Instead of specifying the IP using the tuple notation that Erlang expects (e.g., `{127,0,0,1}`), the var needs to be specified as a common separated list of the octets (e.g., `127,0,0,1`).

This change is backwards compatible with existing deployments. All of the variables default to their existing values.