### PR TITLE
handling non-poc packets in light mode w/o rust gw

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -10,8 +10,7 @@
     port/0,
     position/0,
     location_ok/0,
-    region/0,
-    route/1
+    region/0
 ]).
 
 -export([
@@ -147,19 +146,6 @@ position() ->
 
 -spec location_ok() -> true | false.
 location_ok() ->
-    %% the below code is tested and working.  we're going to roll
-    %% out the metadata update so app users can see their status
-    %% case position() of
-    %%     {error, _Error} ->
-    %%         lager:debug("pos err ~p", [_Error]),
-    %%         false;
-    %%     {ok, _} ->
-    %%         true;
-    %%     %% fix but too far from assert
-    %%     {ok, _, _} ->
-    %%         false
-    %% end.
-
     %% this terrible thing is to fake out dialyzer
     application:get_env(miner, loc_ok_default, true).
 
@@ -629,7 +615,7 @@ handle_packets(_Packets, _Gateway, _RxInstantLocal_us, #state{reg_domain_confirm
     State;
 handle_packets([Packet|Tail], Gateway, RxInstantLocal_us, #state{reg_region = Region, chain = Chain} = State) ->
     Data = base64:decode(maps:get(<<"data">>, Packet)),
-    case ?MODULE:route(Data) of
+    case route(Data) of
         error ->
             ok;
         {onion, Payload} ->

--- a/src/poc/miner_poc_grpc_client_statem.erl
+++ b/src/poc/miner_poc_grpc_client_statem.erl
@@ -941,8 +941,6 @@ handle_check_target_resp(
 ) ->
     ok.
 
-
-
 do_handle_streamed_msg(
     #gateway_resp_v1_pb{
         msg = {poc_challenge_resp, ChallengeNotification},

--- a/test/miner_gateway_mux_integration_SUITE.erl
+++ b/test/miner_gateway_mux_integration_SUITE.erl
@@ -10,15 +10,17 @@
     all/0
 ]).
 
--export([gateway_signing_test/1, gateway_grpc_reconnect_test/1, mux_packet_routing/1]).
+-export([gateway_signing_test/1, gateway_grpc_reconnect_test/1, mux_packet_routing_light/1]).
 
 all() ->
-    [gateway_signing_test, gateway_grpc_reconnect_test, mux_packet_routing].
+    [gateway_signing_test, gateway_grpc_reconnect_test, mux_packet_routing_light].
 
 init_per_suite(Config) ->
     ok = application:load(miner),
     ok = application:set_env(miner, gateway_and_mux_enable, true),
     ok = application:set_env(miner, radio_device, {{127, 0, 0, 1}, 1680, deprecated, deprecated}),
+    ok = application:set_env(miner, gateways_run_chain, false),
+    ok = application:set_env(miner, mode, gateway),
     application:ensure_all_started(miner),
     Config.
 
@@ -67,22 +69,31 @@ gateway_grpc_reconnect_test(_Config) ->
     ?assert(is_process_alive(NewConnectionPid)),
     ok.
 
-mux_packet_routing(Config) ->
+mux_packet_routing_light(Config) ->
     BaseDir = ?config(base_dir, Config),
     Ledger = blockchain_ledger_v1:new(BaseDir),
 
     application:ensure_all_started(meck),
     Parent = self(),
-    meck:new(miner_lora, [passthrough]),
-    meck:expect(miner_lora, route, fun(Packet) ->
+    meck:new(miner_lora_light, [passthrough]),
+    meck:expect(miner_lora_light, route, fun(Packet) ->
         ct:pal("Received packet from the mux: ~p", [Packet]),
         case longfi:deserialize(Packet) of
             {ok, LongfiPacket} ->
                 case is_onion_packet(LongfiPacket) of
-                    true ->
-                        Parent ! {packet_received, longfi_routed};
+                    true -> Parent ! {packet_received, longfi_routed};
                     false ->
-                        Parent ! {packet_received, lora_skipped}
+                        case application:get_env(miner, gateway_and_mux_enable) of
+                            {ok, true} ->
+                                Parent ! {packet_received, lora_skipped},
+                                %% on the first pass assume the gateway handles and drop the packet,
+                                %% then flip the switch for miner to route on the next packet
+                                ok = application:set_env(miner, gateway_and_mux_enable, false);
+                            _ ->
+                                Parent ! {packet_received, lora_routed},
+                                %% on the second pass, reset back to the gateway handling routing
+                                ok = application:set_env(miner, gateway_and_mux_enable, true)
+                        end
                 end;
             error ->
                 Parent ! {packet_received, udp_skipped}
@@ -91,14 +102,15 @@ mux_packet_routing(Config) ->
     end),
     ?assert(is_pid(whereis(miner_mux_port))),
 
-    {ok, RadioPid} = miner_fake_radio_backplane:start_link(11, 6666, [{1680, 16#821fb7fffffffff}]),
+    miner_lora_light:region_params_update(region_us915, []),
 
+    {ok, RadioPid} = miner_fake_radio_backplane:start_link(11, 6666, [{1680, 16#821fb7fffffffff}]),
     ok = miner_fake_radio_backplane:transmit(<<"hello">>, 915.5, 16#821fb7fffffffff),
 
     receive
         {packet_received, PacketType} -> ?assert(PacketType =:= udp_skipped)
     after 2000 ->
-        ct:fail("no packets received")
+        ct:fail("no udp packets received")
     end,
 
     BlockHash = crypto:strong_rand_bytes(32),
@@ -120,7 +132,7 @@ mux_packet_routing(Config) ->
     receive
         {packet_received, PacketType2} -> ?assert(PacketType2 =:= longfi_routed)
     after 2000 ->
-        ct:fail("no packets received")
+        ct:fail("no poc packets received")
     end,
 
     Lora = longfi:serialize(<<0:128/integer-unsigned-little>>, longfi:new(ack, 0, 1, 0, Onion, #{})),
@@ -129,11 +141,19 @@ mux_packet_routing(Config) ->
     receive
         {packet_received, PacketType3} -> ?assert(PacketType3 =:= lora_skipped)
     after 2000 ->
-        ct:fail("no packets received")
+        ct:fail("no lora packets received")
+    end,
+
+    ok = miner_fake_radio_backplane:transmit(Lora, 915.5, 16#821fb7fffffffff),
+
+    receive
+        {packet_receive, PacketType4} -> ?assert(PacketType4 =:= lora_routed)
+    after 2000 ->
+        ct:fail("no lora packets received")
     end,
 
     gen_server:stop(RadioPid),
-    meck:unload(miner_lora),
+    meck:unload(miner_lora_light),
     ok.
 
 is_onion_packet(Packet) ->


### PR DESCRIPTION
adjustments to the miner_lora_light module to handle routing of packets in either the intended light mode when the light gateway is handling routing of non-poc lorawan packets as well as when the rust gateway is disabled but we're otherwise operating with the light version of the onion and lora servers