### PR TITLE
setting sc downlink handler per active lora mod

### DIFF
--- a/src/miner_critical_sup.erl
+++ b/src/miner_critical_sup.erl
@@ -71,9 +71,6 @@ init(_Opts) ->
     %% TODO: Remove when cuttlefish
     MaxInboundConnections = application:get_env(blockchain, max_inbound_connections, 10),
 
-    %% downlink packets from state channels go here
-    application:set_env(blockchain, sc_client_handler, miner_lora),
-
     %% if POCs are over grpc and we are a gateway then dont start the chain
     GatewaysRunChain = application:get_env(miner, gateways_run_chain, true),
     MinerMode = application:get_env(miner, mode, gateway),

--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -329,6 +329,7 @@ handle_info(init, State = #state{following_chain = false}) ->
     %% if we are not following chain then assume validators running POC challenges and thus
     %% the alternative module 'miner_lora_light" will handle lora packets
     %% just need to set required env vars here
+    application:set_env(blockchain, sc_client_handler, miner_lora_light), %% downlink packets from state channels go here
     application:set_env(miner, lora_mod, miner_lora_light),
     application:set_env(miner, onion_server_mod, miner_onion_server_light),
     application:set_env(miner, enable_grpc_client, true),
@@ -347,6 +348,7 @@ handle_info(init, State = #state{radio_udp_bind_ip = UDPIP, radio_udp_bind_port 
                     %% we are in validator POC mode, dont open a socket
                     %% instead let the alternative module 'miner_lora_light' take it
                     %% and have it handle lora packets
+                    application:set_env(blockchain, sc_client_handler, miner_lora_light), %% downlink packets from state channels go here
                     application:set_env(miner, lora_mod, miner_lora_light),
                     application:set_env(miner, onion_server_mod, miner_onion_server_light),
                     application:set_env(miner, enable_grpc_client, true),
@@ -354,6 +356,7 @@ handle_info(init, State = #state{radio_udp_bind_ip = UDPIP, radio_udp_bind_port 
                 NonValidatorChallenger ->
                     %% we are not in validator POC mode, so open a socket as normal
                     %% this module will handle lora packets
+                    application:set_env(blockchain, sc_client_handler, miner_lora), %% downlink packets from state channels go here
                     application:set_env(miner, lora_mod, miner_lora),
                     application:set_env(miner, onion_server_mod, miner_onion_server),
                     application:set_env(miner, enable_grpc_client, false),

--- a/src/miner_lora_light.erl
+++ b/src/miner_lora_light.erl
@@ -203,6 +203,7 @@ handle_cast(_Msg, State) ->
 handle_info(init, State = #state{radio_udp_bind_ip = UDPIP, radio_udp_bind_port = UDPPort, following_chain = false}) ->
     %% if we are not following chain then assume validators are running POC challenges and thus
     %% this module will handle lora packets and will need to open the port
+    application:set_env(blockchain, sc_client_handler, miner_lora_light), %% downlink packets from state channels go here
     application:set_env(miner, lora_mod, miner_lora_light),
     application:set_env(miner, onion_server_mod, miner_onion_server_light),
     application:set_env(miner, enable_grpc_client, true),
@@ -223,6 +224,7 @@ handle_info(init, State = #state{radio_udp_bind_ip = UDPIP, radio_udp_bind_port 
                     lager:debug("poc_challenger_type: ~p", [validator]),
                     %% we are in validator POC mode, open a socket
                     %% this module will handle lora packets
+                    application:set_env(blockchain, sc_client_handler, miner_lora_light), %% downlink packets from state channels go here
                     application:set_env(miner, lora_mod, miner_lora_light),
                     application:set_env(miner, onion_server_mod, miner_onion_server_light),
                     application:set_env(miner, enable_grpc_client, true),
@@ -233,6 +235,7 @@ handle_info(init, State = #state{radio_udp_bind_ip = UDPIP, radio_udp_bind_port 
                     %% we are NOT in validator POC mode, dont open a socket
                     %% instead let the alternative module 'miner_lora' take it
                     %% and handle lora packets
+                    application:set_env(blockchain, sc_client_handler, miner_lora), %% downlink packets from state channels go here
                     application:set_env(miner, lora_mod, miner_lora),
                     application:set_env(miner, onion_server_mod, miner_onion_server),
                     application:set_env(miner, enable_grpc_client, false),

--- a/src/miner_restart_sup.erl
+++ b/src/miner_restart_sup.erl
@@ -50,9 +50,6 @@ init(_Opts) ->
        sig_fun := SigFun
      } = miner_keys:keys(),
 
-    %% downlink packets from state channels go here
-    application:set_env(blockchain, sc_client_handler, miner_lora),
-
     BaseDir = application:get_env(blockchain, base_dir, "data"),
 
     %% Miner Options

--- a/test/miner_ct_utils.erl
+++ b/test/miner_ct_utils.erl
@@ -1164,7 +1164,6 @@ config_node({Miner, {GwApiPort, UDPPort, JSONRPCPort}, ECDH, PubKey, _Addr, SigF
     ct_rpc:call(Miner, application, set_env, [blockchain, max_inbound_connections, TotalMiners*2]),
     ct_rpc:call(Miner, application, set_env, [blockchain, outbound_gossip_connections, TotalMiners]),
     ct_rpc:call(Miner, application, set_env, [blockchain, sync_cooldown_time, 5]),
-    %% ct_rpc:call(Miner, application, set_env, [blockchain, sc_client_handler, miner_test_sc_client_handler]),
     ct_rpc:call(Miner, application, set_env, [blockchain, sc_packet_handler, miner_test_sc_packet_handler]),
     %% set miner configuration
     ct_rpc:call(Miner, application, set_env, [miner, curve, Curve]),


### PR DESCRIPTION
in the transitional phase where we are running under validator challenges/hotspots are no longer following the chain but we have not enabled the embedded gateway-rs packet router we will be using the `miner_lora_light` module to route lora packets received by the gateway. this change allows the correct / active lora module handling packets to register itself with the blockchain_state_channel_client handler so downlink packets can be returned to the source device correctly regardless of which module is currently active.