### PR TITLE
commit defined gw udp port in case of process crash

### DIFF
--- a/src/miner_gateway_port.erl
+++ b/src/miner_gateway_port.erl
@@ -118,7 +118,8 @@ open_gateway_port(KeyPair, Transport, Host, UdpPort, TcpPort) ->
         os_pid = OSPid,
         transport = Transport,
         host = Host,
-        tcp_port = TcpPort
+        tcp_port = TcpPort,
+        udp_port = UdpPort
     }.
 
 cleanup_port(#state{port = Port} = State) ->


### PR DESCRIPTION
ensure the gateway udp port passed to gateway-rs by application config is persisted in the event of failure so it binds to the expected port on restart in the event of a crash instead of the default port.