### PR TITLE
update testnet config to reduce crosstalk with mainnet

### DIFF
--- a/config/testnet-sys.config
+++ b/config/testnet-sys.config
@@ -25,7 +25,7 @@
   ]},
  {libp2p,
   [
-   {use_dns_for_seeds, true},
+   {use_dns_for_seeds, false},
    {seed_dns_cname, "seed.helium.io"},
    {seed_config_dns_name, "_seed_config.helium.io"},
    {similarity_time_diff_mins, 30},
@@ -33,12 +33,8 @@
    {ip_confirmation_host, "https://ifconfig.co"},
    {node_aliases,
     [
-     {"/p2p/112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE", "/ip4/52.8.80.146/tcp/2154"},
-     {"/p2p/112ewJNEUfSg3Jvo276tMjzFC2JzmmZcJJ32CWz2fzYqbyCMMTe1", "/ip4/54.219.236.122/tcp/2154"},
-     {"/p2p/1124CJ9yJaHq4D6ugyPCDnSBzQik61C1BqD9VMh1vsUmjwt16HNB", "/ip4/54.176.88.149/tcp/2154"},
-     {"/p2p/11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv", "/ip4/54.193.165.228/tcp/2154"},
-     {"/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa", "/ip4/44.238.156.97/tcp/2154"},
-     {"/p2p/11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY", "/ip4/13.37.13.24/tcp/2154"}
+     {"/p2p/1ZgnnbgAsFPTPK2GPJ3o3KKQaqFuGx2BQt7hmYMBZPrirgQpKbs", "/ip4/54.244.119.55/tcp/2154"}, %% testnet seed oregon
+     {"/p2p/1ZyDcjdcHuBoozoma477jJeyL5KRnzRofA6g3838drPu9RfcjEw", "/ip4/3.22.146.211/tcp/443"} %% testnet seed ohio
     ]}
   ]},
  {blockchain,
@@ -56,7 +52,7 @@
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},
-   {seed_nodes, "/ip4/54.244.119.55/tcp/2154"},
+   {seed_nodes, "/ip4/54.244.119.55/tcp/2154,/ip4/3.22.146.211/tcp/443"},
    {seed_node_dns, ""},
    {peerbook_update_interval, 900000},
    {max_inbound_connections, 6},
@@ -121,7 +117,7 @@
    {election_interval, 30},
    {radio_device, { {0,0,0,0}, 1680, %% change to 1681 when activating mux+gateway-rs
                     {0,0,0,0}, 31341} },
-   {default_routers, ["/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa","/p2p/11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY"]},
+   {default_routers, ["/p2p/11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa","/p2p/11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY"]}, %% mainnet routers, should update when there are routers available on testnet
    {mark_mods, [miner_hbbft_handler]},
    {stabilization_period, 50000},
    {seed_validators, [


### PR DESCRIPTION
- do not use dns for seeds (that only provides mainnet seeds)
- add both testnet seeds to seed_nodes
- add aliases for the testnet seeds
- remove aliases for mainnet nodes