### PR TITLE
update version of embedded gateway with mawr vals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 GRPC_SERVICES_DIR=src/grpc/autogen
 
-GATEWAY_RS_VSN ?= "54c6a32f4a021b6abdedd1c769363b8d73feb158"
+GATEWAY_RS_VSN ?= "13931ef7c9a96bc45a1628fc3dd5f24fe5ffc477"
 GWMP_MUX_VSN ?= "v0.9.4"
 
 all: compile


### PR DESCRIPTION
The rust light gateway has added additional seed validators to handle the load of a vastly expanded fleet of miners switching over to grpc/non-chain subscriptions to the validator fleet so the miner needs to update the version of the gateway embedded in the package to take advantage of these new validators.