### PR TITLE
Adding missing additional seed validators to the config

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -122,11 +122,38 @@
    {mark_mods, [miner_hbbft_handler]},
    {stabilization_period, 50000},
    {seed_validators, [
-       {"11tk4zzbyfMPYYHYda255ACoqfYFVdrUSoCWrCYfn8BoyuYrERK", "52.49.199.40", 8080},     %% ireland
-       {"115PmCR6fpFihdjw626JXYdUEdzwjh66yoWzWkMvB9CRGEx1U6G", "3.132.190.192", 8080},    %% ohio
-       {"11pUovhssQdXzrfcYMTUrNNTQossgny8WqhfdbprrAVFyHcmvAN", "35.84.173.125", 8080},    %% oregon
-       {"11yJXQPG9deHqvw2ac6VWtNP7gZj8X3t3Qb3Gqm9j729p4AsdaA", "3.38.70.101", 8080},      %% seoul
-       {"11Gx2yPEmBGUrbHUiUWQs9vV7JDHQLZSddQs6e3WB2uvqSMUDBW", "54.251.77.229", 8080}     %% singapore
+       {"11tk4zzbyfMPYYHYda255ACoqfYFVdrUSoCWrCYfn8BoyuYrERK", "52.49.199.40"},     %% ireland
+       {"115PmCR6fpFihdjw626JXYdUEdzwjh66yoWzWkMvB9CRGEx1U6G", "3.132.190.192"},    %% ohio
+       {"11aZEJnSduAXG8r3r9vzw3QD5k1KWXUJSVc2SxmwxPBuNmMW6UY", "44.229.159.157"},   %% oregon
+       {"11yJXQPG9deHqvw2ac6VWtNP7gZj8X3t3Qb3Gqm9j729p4AsdaA", "3.38.70.101"},      %% seoul
+       {"11Gx2yPEmBGUrbHUiUWQs9vV7JDHQLZSddQs6e3WB2uvqSMUDBW", "54.251.77.229"},    %% singapore
+       {"1123BGjiBwxdTHHjEuvF5mTQpHWwy9KP1JbgS8N4UKUa3Q2ya1W6", "3.122.38.248"},    %% frankfurt1
+       {"11BL23u2PbpTjuCyHQ6n35xD5a1QyhyuepCJYrqLVgD3fFewkJ2", "18.228.115.118"},   %% saopaulo1
+       {"11EQ9yjSuqBG1yV73YL1YRSX4QVwdQiiF9MJ1Bqngf9JwS2TGBi", "13.237.155.172"},   %% sydney1
+       {"11pGEgAb8YhhFw64pxDLDsoaLQyQG1cijQjR1Ko6A2Q7EtwBcy9", "3.72.143.228"},     %% frankfurt2
+       {"112qiiykzk7kTrnxNwnzf2EUsG9qoFPHG4Mau5hNsok8dLGf8ufB", "52.30.1.39"},      %% ireland2
+       {"11fHGw18ySqmiBRhgBEXHS9xfSvBpmES5aeL1HNb5G79fQc67Ch", "3.137.92.200"},     %% ohio2
+       {"112LdZBP1vtz3gdhVPRuQYGx1fLuBP5nqFWcE4L1dYXdNiMJRdF6", "35.82.239.134"},   %% oregon2
+       {"11WUPL9y8pUfQg8wYvyJWbqEjnN7AzVGVWwHD8hmFFsXdaE3yh6", "18.228.158.83"},    %% saopaulo2
+       {"11Gn8cr7tNDVv7GSnuDpJAqEjnDWRWkfEzW8zph7EQ9rr8MLhPJ", "13.209.94.225"},    %% seoul2
+       {"112fVSokVAUxmD672gKbS86SuqKX3bTzu2SGNaGuq6vxESMGBqCN", "52.220.227.216"},  %% singapore2
+       {"112Go1gHKBNBjSJztRD1x9m4H9krFiawrU444VC6PbEiwmWvFAUu", "3.24.161.210"},    %% sydney2
+       {"11NeSZjVWK9SvXxfwaWc3vZU8df17TYbKQekywYktbUyow3efUm", "3.70.55.231"},      %% frankfurt3
+       {"11vBe5pfSxH5QoEgFMVedA631YMEeBHipktJ2nybDe1EjkiKRXo", "52.30.111.82"},     %% ireland3
+       {"112HUu9fVtpcNJtnnAwXTNPBPZjWZxV63angT5UJY529APS5hMDa", "3.13.130.184"},    %% ohio3
+       {"112mjDiAz72CFxkjxBgwieP1LxAhV8oadqHNP2AyaiQQom4VN27", "54.70.239.5"},      %% oregon3
+       {"11rfZwFwdDDtxYo34uYTXUKbkPhZofxJ2LbkduBZHPksHUsUdw8", "18.230.8.198"},     %% saopaulo3
+       {"11BgGQp83rWWE8PHimZQPYxwMVD3oQw9JaVW7u3EUom6toh9568", "13.125.32.225"},    %% seoul3
+       {"112fVGeUJf6aNc5z6d8rFDsgBnRj45BAxhdxaEVpQ58SGFJ1abk4", "13.215.75.202"},   %% singapore3
+       {"11FiQQ2dGuwRi3XAWfGboPwgxH7JiNzak8BfGWpJTJ3NXHG3N6i", "3.104.32.11"},      %% syndey3
+       {"112pcepAfZ8CWGFcRAq8hPP8dNcppRK8APSNfrKvqufyH3Keyhjb", "3.72.215.7"},      %% frankfurt4
+       {"112wJBZBZH34G2NZ8XQx8ZpFXAhZf5FUhyKwbobknkBraP9pH2j8", "52.210.14.128"},   %% ireland4
+       {"112hyDbnmq41LwyNynmSkcjoH414oEdANHiYduFygbLbJWBoLjsZ", "3.131.232.233"},   %% ohio4
+       {"112N96HhzTGGwVeCengwf7CUoGK73GgLquZskDvRzrTqSQvsU3rM", "52.89.130.114"},   %% oregon4
+       {"11Ka5aFf1heCuQLQWt3D2itZX89QJNetPHUeUdNcC55Jtp6SRaV", "54.207.131.103"},   %% saopaulo4
+       {"112iJa3Ckk34eFiWSfDUkLz12qwdcJS4V3794zgCw2rJDHi4naiL", "3.39.165.144"},    %% seoul4
+       {"112USfBeZqQwhQtgeTRwREauyxxFQdCw5eFw23GUa3eMqTRqyhXt", "13.215.29.4"},     %% singapore4
+       {"112q3CB7MsFpi7Y3JuiHzF9h2ndH88KeZ3LUL6juJwMdo4g4Lsoq", "13.211.55.217"}    %% sydney4
    ]},
    {reg_domains_file, "countries_reg_domains.csv"},
    {frequency_data, #{'US915' => [903.9, 904.1, 904.3, 904.5, 904.7, 904.9, 905.1, 905.3],

--- a/src/poc/miner_poc_grpc_client_statem.erl
+++ b/src/poc/miner_poc_grpc_client_statem.erl
@@ -437,7 +437,10 @@ find_validator() ->
     case application:get_env(miner, seed_validators) of
         {ok, SeedValidators} ->
             {_SeedP2PAddr, SeedValIP, SeedValGRPCPort} =
-                lists:nth(rand:uniform(length(SeedValidators)), SeedValidators),
+                case lists:nth(rand:uniform(length(SeedValidators)), SeedValidators) of
+                    {_SeedP2PAddr0, SeedValIP0, SeedValGRPCPort} = AddrAndPort when is_integer(SeedValGRPCPort) -> AddrAndPort;
+                    {_SeedP2PAddr0, SeedValIP0} -> {_SeedP2PAddr0, SeedValIP0, 8080}
+                end,
             Req = build_validators_req(1),
             case send_grpc_unary_req(SeedValIP, SeedValGRPCPort, Req, 'validators') of
                 {ok, #gateway_validators_resp_v1_pb{result = []}, _ReqDetails} ->


### PR DESCRIPTION
These seed validators have been added to the rust light gateway's config but not to the miner's config. This change fixes that and allows for omitting the port number from the config since that has a reliable default value in 8080