### PR TITLE
add denylist keys to mainnet vals to enable worker

### DIFF
--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -40,7 +40,6 @@
   ]},
  {miner,
   [
-   {denylist_keys, undefined},
    {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
    {mode, validator},
    {rocksdb_cache_size, 32},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -41,7 +41,6 @@
   ]},
  {miner,
   [
-   {denylist_keys, undefined},
    {mode, validator},
    {rocksdb_cache_size, 32},
    {rocksdb_write_buffer_size, 32},


### PR DESCRIPTION
We need to set keys for the denylist properly on miners built with the mainnet validator profile so the proper denylist worker is started. This change does so for mainnet profiles (not testnet) and also disables the denylist for miners so they are no longer running the denylist.