### PR TITLE
enable the mux/embedded light gateway

### DIFF
--- a/config/docker.config
+++ b/config/docker.config
@@ -14,6 +14,7 @@
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
      {radio_device, { {0,0,0,0}, 1680,
                       {0,0,0,0}, 31341} },
-     {use_ebus, false}
+     {use_ebus, false},
+     {gateway_and_mux_enable, true}
     ]}
 ].


### PR DESCRIPTION
Turn on the embedded rust light gateway and mux for dockerized miners