### PR TITLE
if challenger and notifier are same height, retry pocs with queued response

### DIFF
--- a/src/poc/miner_poc_grpc_client_statem.erl
+++ b/src/poc/miner_poc_grpc_client_statem.erl
@@ -922,10 +922,11 @@ check_if_target(
                 %% seems the POC key exists but the POC itself may not yet be initialised
                 %% this can happen if the challenging validator is behind our
                 %% notifying validator
-                %% if the challenger is behind the notifier, then add cache the check target req
-                %% it will then be retried periodically
+                %% if the challenger height is behind or equal
+                %% to the notifier, then cache the check target req
+                %% and retry it periodically
                 N = NotificationHeight - ValRespHeight,
-                case (N > 0) andalso (not IsRetry) of
+                case (N >= 0) andalso (not IsRetry) of
                     true ->
                         CurTSInSecs = erlang:system_time(second),
                         _ = cache_check_target_req(


### PR DESCRIPTION
when a client checks if they are the target with the challenger, it can receive a queued_poc response.  This means the challenger recognises the key as its own but there is no active POC as yet.

The client can then make the decision to retry the request again later.  When making that decision the challenger had to be behind the notifying validator.  With this change, the request will be retried when the notifying val and the challenger are at the same height.

