### PR TITLE
ara/add-docker-container-devrel-support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.159.0/containers/javascript-node
+{
+	"name": "Erlang",
+	"build": {
+		"dockerfile": "remote.Dockerfile",
+		"args": { "VARIANT": "24.3.4.0-alpine" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/sh"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"pgourlain.erlang"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [3000],
+}

--- a/.devcontainer/remote.Dockerfile
+++ b/.devcontainer/remote.Dockerfile
@@ -1,0 +1,24 @@
+# [Choice] alpine,...
+ARG VARIANT="alpine"
+FROM erlang:${VARIANT} as deps-compiler
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Setup rebar diagnostics
+ARG REBAR_DIAGNOSTIC=0
+ENV DIAGNOSTIC=${REBAR_DIAGNOSTIC}
+
+ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" \
+    ERLANG_ROCKSDB_OPTS="-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON" \
+    ERL_COMPILER_OPTIONS="[deterministic]" \
+    PATH="/root/.cargo/bin:$PATH" \
+    RUSTFLAGS="-C target-feature=-crt-static"
+
+# Install dependencies to build
+RUN apk add --no-cache --update \
+    autoconf automake bison build-base bzip2 cmake curl \
+    dbus-dev flex git gmp-dev libsodium-dev libtool linux-headers lz4 \
+    openssl-dev pkgconfig protoc sed tar wget bash parallel
+
+# Install Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
# Reason

This PR is meant to make developing on a Mac M1 less ... difficult. It allows you to compile and test changes locally compared to a remote host (still allows for remote host connections). This enables you to build a docker container with the correct build dependencies for development of the Helium miner.

# VScode Extensions Needed

Name: Remote Development
Id: ms-vscode-remote.vscode-remote-extensionpack
Description: An extension pack that lets you open any folder in a container, on a remote machine, or in WSL and take advantage of VS Code's full feature set.
Version: 0.21.0
Publisher: Microsoft
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack

Name: Docker
Id: ms-azuretools.vscode-docker
Description: Makes it easy to create, manage, and debug containerized applications.
Version: 1.22.0
Publisher: Microsoft
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker

Name: erlang
Id: pgourlain.erlang
Description: Erlang language extension for Visual Studio Code
Version: 0.8.4
Publisher: Pierrick Gourlain
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=pgourlain.erlang