### PR TITLE
audit 134

### DIFF
--- a/audit/var-133.md
+++ b/audit/var-133.md
@@ -1,4 +1,4 @@
-# Chain Variable Transaction 132
+# Chain Variable Transaction 133
 
 ## Changes
 

--- a/audit/var-134.md
+++ b/audit/var-134.md
@@ -1,0 +1,32 @@
+# Chain Variable Transaction 134
+
+## Changes
+
+This transaction changes `poc_challenge_rate` from `400` to `700`.
+
+## Version threshold
+
+None
+
+## Transaction
+
+```
+[{1354745,
+  {blockchain_txn_vars_v1_pb,[{blockchain_var_v1_pb,"poc_challenge_rate",
+                                                    "int",<<"700">>}],
+                             0,
+                             <<48,68,2,32,82,221,125,50,139,57,96,133,121,110,223,140,
+                               228,77,0,169,84,15,149,195,23,59,90,233,223,27,17,251,
+                               36,96,32,214,2,32,106,255,171,182,77,169,127,102,112,
+                               251,232,38,86,172,215,168,52,177,223,51,132,239,182,59,
+                               2,126,164,76,115,184,183,100>>,
+                             <<>>,<<>>,[],[],134,[],[],[]}}]
+```
+
+## Acceptance block
+
+1354745
+
+## Acceptance block time
+
+Sat May 14 15:50:16 UTC 2022


### PR DESCRIPTION
Adds the audit record for chainvar 134 upping the PoC rate interval from 400 to 700.

Includes a small cleanup to a broken logging format string and a correction to the header line of the audit for var 133