### PR TITLE
various check target request improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 GRPC_SERVICES_DIR=src/grpc/autogen
 
-GATEWAY_RS_VSN ?= "v1.0.0-alpha.24"
+GATEWAY_RS_VSN ?= "72fc301c895e33d30d1cb9207fe7e9c591602371"
 GWMP_MUX_VSN ?= "v0.9.4"
 
 all: compile

--- a/src/poc/miner_poc_mgr.erl
+++ b/src/poc/miner_poc_mgr.erl
@@ -686,7 +686,8 @@ submit_receipts(
         responses = Responses0,
         secret = Secret,
         packet_hashes = LayerHashes,
-        block_hash = BlockHash
+        block_hash = BlockHash,
+        target = Target
     } = _Data,
     Challenger,
     SigFun,
@@ -694,7 +695,7 @@ submit_receipts(
 ) ->
     case maps:size(Responses0) of
         0 ->
-            lager:info("POC timed out with no responses @ ~p", [OnionKeyHash]),
+            lager:info("POC timed out with no responses for key ~p & target ~p", [OnionKeyHash, ?TO_ANIMAL_NAME(Target)]),
             ok;
         _ ->
             PerHopMaxWitnesses = blockchain_utils:poc_per_hop_max_witnesses(Ledger),
@@ -727,7 +728,7 @@ submit_receipts(
                         %% hmm we shouldnt really hit here as this all started with poc version 10
                         noop
                 end,
-            lager:info("submitting blockchain_txn_poc_receipts_v2 for onion key hash ~p: ~p", [OnionKeyHash, Txn0]),
+            lager:info("submitting blockchain_txn_poc_receipts_v2. challenger: ~p, target: ~p, onionkeyhash ~p: txn: ~p", [?TO_ANIMAL_NAME(Challenger), ?TO_ANIMAL_NAME(Target), OnionKeyHash, Txn0]),
             Txn1 = blockchain_txn:sign(Txn0, SigFun),
             ok = blockchain_txn_mgr:submit(Txn1, fun(_Result) -> noop end)
     end.

--- a/src/poc/miner_poc_mgr.erl
+++ b/src/poc/miner_poc_mgr.erl
@@ -542,7 +542,8 @@ initialize_poc(BlockHash, POCStartHeight, Keys, Vars, Ledger, #state{pub_key = C
                         start_height = POCStartHeight
                     },
                     ok = write_local_poc(LocalPOC, State),
-                    lager:info("started poc for challengeraddr ~p, onionhash ~p", [?TO_ANIMAL_NAME(Challenger), OnionKeyHash]),
+                    lager:info("started poc for challengeraddr ~p, target: ~p, onionhash ~p",
+                        [?TO_ANIMAL_NAME(Challenger), OnionKeyHash]),
                     ok
             end
     end.


### PR DESCRIPTION
- retry check target requests if grpc req fails
- serialise check target requests, dont spawn off
- remove sync call during check target to blockchain_swarm:get_keys/0
- prevent connection close calls from crashing, if already dead