### PR TITLE
Disable hotspot's poc_statem on vals

### DIFF
--- a/src/miner_restart_sup.erl
+++ b/src/miner_restart_sup.erl
@@ -105,7 +105,6 @@ init(_Opts) ->
                            },
                 [
                     ?WORKER(miner_poc_mgr_db_owner, [POCOpts]),
-                    ?WORKER(miner_poc_statem, [POCOpts]),
                     ?WORKER(miner_poc_mgr, [])
                 ];
             gateway ->


### PR DESCRIPTION
The PoC Statem isn't really doing anything on a validator build so suggested disabling completely. This is likely a tiny optimization but at the very least cleans up the conceptual model of the running system in the validator configuration.