### PR TITLE
ara/update-queue-time-once

### DIFF
--- a/src/poc/miner_poc_grpc_client_statem.erl
+++ b/src/poc/miner_poc_grpc_client_statem.erl
@@ -1021,7 +1021,14 @@ handle_check_target_resp(
     ChallengerSig :: binary()
 ) -> ok.
 queue_check_target_req(OnionKeyHash, URI, PubKeyBin, BlockHash, NotificationHeight, ChallengerSig) ->
-    CurTSInSecs = erlang:system_time(second),
+    CurTSInSecs = case ets:match(?CHECK_TARGET_REQS, {OnionKeyHash, $1}) of
+        %% should only match one
+        [[Match]] ->
+            {_ChallengerURI, _ChallengerPubKeyBin, _OnionKeyHash, _BlockHash, _NotificationHeight, _ChallengerSig, QueueEnterTSInSecs} = Match,
+            QueueEnterTSInSecs;
+        [] ->
+            erlang:system_time(second)
+    end,
     _ = cache_check_target_req(
         OnionKeyHash,
         {URI, PubKeyBin, OnionKeyHash, BlockHash, NotificationHeight,


### PR DESCRIPTION
I noticed that the queue time was "updated" every time that a hotspot got the "queue_poc" or "req_failed" response from `check_target` with this queue time being used in `process_check_target_reqs` it should be only update on first entrance into the queue. This will ensure the past due removal works as intended.

So prior to re-inserting the req into the queue, see if there's one already. If there is, use the already given queue time for the update. Not sure, if anything outside of it should change... maybe there's a better approach here also just what came to mind for me at the time.