### PR TITLE
harmonize local keys GC cadence with ledger key proposals GC interval

### DIFF
--- a/src/poc/miner_poc_mgr.erl
+++ b/src/poc/miner_poc_mgr.erl
@@ -336,8 +336,10 @@ handle_add_block_event(POCChallengeType, BlockHash, Ledger, State) when POCChall
             %% take care of GC
             ok = purge_local_pocs(Block, Ledger, State),
 
-            %% GC local pocs keys every 50 blocks
-            case BlockHeight rem 50 == 0 of
+            %% GC local pocs keys every 101 blocks
+            %% this is tied to the GC cadence window
+            %% for the key propopsals in ledger v1
+            case BlockHeight rem 101 == 0 of
                 true ->
                     ok = purge_local_poc_keys(BlockHeight, Ledger, State);
                 false ->


### PR DESCRIPTION
When generating ephemeral keys for a POC, a validator will generate key pairs.   The public key will be proposed in the its heartbeats and end up on the ledger proposed pocs CF, whilst the private key will be saved to a local rocks DB via miner_poc_mgr.

These two keys are intrinsically linked, if a public key is selected/promoted then in order for the POC to initiate the owning validator must still have the associated private key.  However the GC implementation for these key stores were running at a different cadence...the public keys would have a GC run every 101 blocks whilst the private keys would have a GC run every 50 blocks.

This allowed for the possibility of a local private key being removed prior to the public key. Should the public key then be selected the POC would fail.

This fix harmonises the cadence of both.

TODO: is a chain var necessary here ?  I dont believe so as it impacts only local data....but that local data does influence if a POC initiates or not ????

