### PR TITLE
console.log >= 30MB, rollover 00 keep +3 rotated

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -14,7 +14,7 @@
    {metadata_whitelist, [poc_id]},
    {handlers,
     [
-     {lager_file_backend, [{file, "console.log"}, {level, info},
+     {lager_file_backend, [{file, "console.log"}, {level, info}, {size, 31457280}, {date, "$D0"}, {count, 3}, %% console.log >= 30MB, rolls over at 00:00 and keeps +3 rotated logs
                            {formatter, lager_default_formatter},
                            {formatter_config, [date, " ", time, " ", {pterm, ospid, <<"NOPID">>},
                                                " [",severity,"] ",


### PR DESCRIPTION
since light HS console.log fills up rather quickly. Proposing log file size increase with rotation forced at mid-night (00:00) and to keep +3 copies instead of 5 as now 30mb *3=90mb + current log, would be used for logs instead of 10mb*5=50mb + current log. This would help collect a full days worth of stats from the console.log file without having to append segments console.log.0,1,2,... to see daily data.
Examples of 3rd party utility that is utilizing console.log
* <https://github.com/saad-akhtar/helium_miner_checker_light>
* <https://github.com/inigoflores/helium-miner-log-analyzer>