### PR TITLE
update testnet gatewayrs configs for router list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 GRPC_SERVICES_DIR=src/grpc/autogen
 
-GATEWAY_RS_VSN ?= "72fc301c895e33d30d1cb9207fe7e9c591602371"
+GATEWAY_RS_VSN ?= "6dfeb3f329593af2bf4d9da99ef3651299351f4a"
 GWMP_MUX_VSN ?= "v0.9.4"
 
 all: compile

--- a/priv/gateway_rs/testnet.settings
+++ b/priv/gateway_rs/testnet.settings
@@ -17,6 +17,6 @@ uri = "http://3.17.164.253:8080"
 pubkey = "1ZAxCrEsigGVbLUM37Jki6p88kyZ5NVqjVC6oHSbqu49t7bQDym"
 uri = "http://18.191.60.231:8080"
 
-[router.testnet]
+[[routers]]
 pubkey = "1ZLxTAB8Bs7BXySp5HqHhtCos6JtzzV2mfZjofEGT1MQVTKqYQT"
 uri = "http://34.215.110.61:8080"


### PR DESCRIPTION
Gateway-rs needs to support multiple default routers so it now takes a vector of keyed uris instead of a map keyed by the release channel. This updates the commit for the gateway-rs embedded in the erlang miner and the testnet configs for the embedded gateway to continue routing testnet packets to the testnet default router.