### PR TITLE
stream related grpc client fixes

### DIFF
--- a/src/miner_query.erl
+++ b/src/miner_query.erl
@@ -13,7 +13,9 @@
          txns/2, txns/3,
          blocks/2,
          lookup_txns_by_hash/2,
-         lookup_txns_by_type/2]).
+         lookup_txns_by_type/2,
+         lookup_txns_by_onionhash/2
+]).
 
 poc_analyze(_Start, _End) ->
     ok.
@@ -84,6 +86,28 @@ lookup_txns_by_hash(LastXBlocks, TxnHash) ->
                 case lists:filter(fun(T) ->
                                           blockchain_txn:hash(T) == TxnHash
                                   end, blockchain_block:transactions(B)) of
+                    [] -> Acc;
+                    R -> [{I, R} | Acc]
+                end
+        end,
+        Current - LastXBlocks, Current, C,
+        [])).
+
+lookup_txns_by_onionhash(LastXBlocks, OnionHash) ->
+    C = blockchain_worker:blockchain(),
+    {ok, Current} = blockchain:height(C),
+    lists:reverse(
+      fold_blocks(
+        fun(B, Acc) ->
+                I = blockchain_block:height(B),
+                case lists:filter(fun(T) ->
+                        case blockchain_txn:type(T) == 'blockchain_txn_poc_receipts_v2' of
+                            true ->
+                                blockchain_txn_poc_receipts_v2:onion_key_hash(T) == OnionHash;
+                            _ ->
+                                false
+                        end
+                    end, blockchain_block:transactions(B)) of
                     [] -> Acc;
                     R -> [{I, R} | Acc]
                 end

--- a/src/poc/grpc_client_stream_custom.erl
+++ b/src/poc/grpc_client_stream_custom.erl
@@ -69,7 +69,11 @@
       buffer := binary(),
       handler_callback := undefined,
       handler_state := undefined,
-      type := unary | streaming | undefined}.
+      type := unary | streaming | undefined,
+      conn_monitor_ref := reference()
+    }.
+
+-export_type([stream/0]).
 
 -spec new(Connection::grpc_client_custom:connection(),
           Service::atom(),
@@ -121,14 +125,19 @@ call_rpc(Pid, Message, Timeout) ->
 
 %% gen_server implementation
 %% @private
-init({Connection, Service, Rpc, Encoder, Options, HandlerMod}) ->
+init({#{http_connection := ConnPid} = Connection, Service, Rpc, Encoder, Options, HandlerMod}) ->
     try
         StreamType = proplists:get_value(type, Options, undefined),
         lager:info("init stream for RPC ~p and type ~p", [Rpc, StreamType]),
         Stream =  new_stream(Connection, Service, Rpc, Encoder, Options),
         lager:info("init stream success with state ~p, handle_mod: ~p", [Stream, HandlerMod]),
         HandlerState = HandlerMod:init(),
-        {ok, Stream#{handler_state => HandlerState, handler_callback => HandlerMod, type => StreamType}}
+        %% monitor our connection, so we can tear down stream if conn dies
+        Ref = monitor(process, ConnPid),
+        {ok, Stream#{handler_state => HandlerState,
+                     handler_callback => HandlerMod,
+                     type => StreamType,
+                     conn_monitor_ref => Ref}}
     catch
         _Class:_Error:_Stack ->
             lager:warning("failed to create stream, ~p ~p ~p", [_Class, _Error, _Stack]),
@@ -239,6 +248,9 @@ handle_info(timeout, #{response_pending := true,
                        client := Client} = Stream) ->
     gen_server:reply(Client, {error, timeout}),
     {noreply, Stream#{response_pending => false}};
+handle_info({'DOWN', Ref, process, _, _Reason}, #{conn_mon := Ref} = C) ->
+    %% our connection is down, nothing more stream can do other then terminate
+    {stop, connection_down, C};
 handle_info(Msg, #{handler_callback := HandlerCB} = Stream) ->
     NewState =
         case erlang:function_exported(HandlerCB, handle_info, 2) of
@@ -246,8 +258,6 @@ handle_info(Msg, #{handler_callback := HandlerCB} = Stream) ->
             false -> Stream
         end,
     {noreply, NewState}.
-%%handle_info(_InfoMessage, Stream) ->
-%%    {noreply, Stream}.
 
 %% @private
 terminate(_Reason, _State) ->
@@ -355,13 +365,10 @@ info_response(Response, #{response_pending := true,
 info_response(Response, #{queue := Queue, type := unary} = Stream) ->
     NewQueue = queue:in(Response, Queue),
     {noreply, Stream#{queue => NewQueue}};
-%%info_response(Response, #{queue := Queue} = Stream) ->
-%%    NewQueue = queue:in(Response, Queue),
-%%    {noreply, Stream#{queue => NewQueue}}.
-
-info_response(eof = Response, #{type := Type} = Stream) ->
+info_response(eof = Response, #{type := Type, state := closed} = Stream) ->
     lager:info("info_response ~p, stream type: ~p", [Response, Type]),
     {stop, normal, Stream};
+%% pass any unmatched info msg to our handler
 info_response(Response, #{handler_callback := CB, handler_state := CBState} = Stream) ->
     lager:info("info_response ~p, CB: ~p", [Response, CB]),
     NewCBState = CB:handle_msg(Response, CBState),

--- a/src/poc/miner_poc_grpc_client_statem.erl
+++ b/src/poc/miner_poc_grpc_client_statem.erl
@@ -697,7 +697,8 @@ send_grpc_unary_req(Connection, Req, RPC) ->
             'helium.gateway',
             RPC,
             gateway_miner_client_pb,
-            [{callback_mod, miner_poc_grpc_client_handler}]
+            [{callback_mod, miner_poc_grpc_client_handler},
+             {timeout, 10000}]
         ),
         lager:info("send unary result: ~p", [Res]),
         process_unary_response(Res)
@@ -723,7 +724,8 @@ send_grpc_unary_req(PeerIP, GRPCPort, Req, RPC) ->
             'helium.gateway',
             RPC,
             gateway_miner_client_pb,
-            [{callback_mod, miner_poc_grpc_client_handler}]
+            [{callback_mod, miner_poc_grpc_client_handler},
+             {timeout, 10000}]
         ),
         lager:info("New Connection, send unary result: ~p", [Res]),
         %% we dont need the connection to hang around, so close it out
@@ -1234,7 +1236,8 @@ send_block_age_req(Connection) ->
             'helium.gateway',
             config,
             gateway_miner_client_pb,
-            [{callback_mod, miner_poc_grpc_client_handler}]
+            [{callback_mod, miner_poc_grpc_client_handler},
+             {timeout, 10000}]
         ) of
             {ok, #{http_status := 200, result := #gateway_resp_v1_pb{block_age = BlockAge}}} when is_integer(BlockAge) ->
                 {ok, BlockAge};

--- a/test/miner_poc_grpc_SUITE.erl
+++ b/test/miner_poc_grpc_SUITE.erl
@@ -584,11 +584,11 @@ extra_vars(grpc, TargetVersion) ->
                  ?poc_activity_filter_enabled => true,
                  ?validator_hb_reactivation_limit => 100,
                  ?poc_validator_ct_scale => 0.8,
-%%                 ?h3dex_gc_width => 10,
-%%                 ?poc_target_hex_parent_res => 5,
-%%                 ?poc_target_hex_collection_res => 5,
-%%                 ?poc_target_pool_size => 2,
-%%                 ?poc_hexing_type => hex_h3dex,
+                 ?h3dex_gc_width => 10,
+                 ?poc_target_hex_parent_res => 5,
+                 ?poc_target_hex_collection_res => 7,
+                 ?poc_target_pool_size => 2,
+                 ?poc_hexing_type => hex_h3dex,
                  ?hip17_interactivity_blocks => 20
     },
     maps:merge(extra_vars(poc_v11), GrpcVars).


### PR DESCRIPTION
1.  Adds a monitor to the stream process of the parent connection process. If that terminates then shutdown the stream process
2.  Specifies a timeout for unary grpc requests.  If no timeout is specified the grpc client lib would default to infinity
3.  Adds a query to find txns by onion key hash
4.  Logging tweaks