### PR TITLE
Reduce invalid block age threshold

### DIFF
--- a/src/poc/miner_poc_grpc_client_statem.erl
+++ b/src/poc/miner_poc_grpc_client_statem.erl
@@ -85,10 +85,10 @@
 %% max number of stream down events  within the STREAM_STABILITY_CHECK_TIMEOUT period
 %% after which we will select a new validator
 -define(MAX_DOWN_EVENTS_IN_PERIOD, (?STREAM_STABILITY_CHECK_TIMEOUT / ?RECONNECT_DELAY) - 2).
--define(BLOCK_AGE_TIMEOUT, 450000).
 %% Maximum block age returned by a connected validator before triggering an instability reconnect
 %% Measured in seconds as this is the unit of time returned by the validator for block_age
--define(MAX_BLOCK_AGE, 900).
+-define(MAX_BLOCK_AGE, 600).
+-define(BLOCK_AGE_TIMEOUT, (?MAX_BLOCK_AGE / 2) * 1000).
 %% ets table name for check target reqs cache
 -define(CHECK_TARGET_REQS, check_target_reqs).
 -type data() :: #data{}.


### PR DESCRIPTION
Reduces the maximum block age a miner client will allow from a durable validator from 900 (roughly 15 min) to 600 (roughly 10 min) to ensure clients are ditching under-performing durable validators in favor of ones that are keeping better pace with the chain.

Also updates the timeout constant the client uses to trigger checks of a connected durable validator's block age to compute based on the maximum allowed block age. Keeps the formula previously in place but now computes it based on changes to the `MAX_BLOCK_AGE` to always be roughly half the allowed maximum block age in milliseconds. The check timeout is roughly half the allowed maximum block age plus a jitter of up to another half the allowed maximum block age.