### PR TITLE
pull in gateway-rs alpha26 pre-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 GRPC_SERVICES_DIR=src/grpc/autogen
 
-GATEWAY_RS_VSN ?= "6dfeb3f329593af2bf4d9da99ef3651299351f4a"
+GATEWAY_RS_VSN ?= "v1.0.0-alpha.26"
 GWMP_MUX_VSN ?= "v0.9.4"
 
 all: compile


### PR DESCRIPTION
The latest alpha26 tagged pre-release of the gateway-rs embedded in the miner includes some improvements to the gateway including supporting multiple default routers instead of a single one per release channel and supports retrieval of a `version_info()` API from durable validators to allow the gateway to refuse or reject a durable validator that is not running some minimum version of the miner/validator software once the gateway is no longer running the blockchain to allow feature-gating based on a chain var.