### PR TITLE
set test chain var, required by h3dex targeting

### DIFF
--- a/test/miner_poc_grpc_SUITE.erl
+++ b/test/miner_poc_grpc_SUITE.erl
@@ -627,7 +627,8 @@ extra_poc_vars() ->
       ?poc_v4_randomness_wt => 0.5,
       ?poc_v4_prob_count_wt => 0.0,
       ?poc_centrality_wt => 0.5,
-      ?poc_max_hop_cells => 2000}.
+      ?poc_max_hop_cells => 2000,
+      ?poc_witness_consideration_limit => 2}.
 
 check_subsequent_path_growth(ReceiptMap) ->
     PathLengths = [ length(blockchain_txn_poc_receipts_v2:path(Txn)) || {_, Txn} <- lists:flatten(maps:values(ReceiptMap)) ],


### PR DESCRIPTION
This sets a chain var as part of the grpc test suite to enable `poc_witness_consideration_limit`.

With PR https://github.com/helium/blockchain-core/pull/1378 h3dex assumes this var is set. The var is already long enabled on mainnet but was never set in the test suite.