### PR TITLE
disable the mux to bypass an issue that requires testing

### DIFF
--- a/config/docker.config
+++ b/config/docker.config
@@ -14,7 +14,6 @@
      {jsonrpc_ip, {0,0,0,0}}, %% bind jsonrpc to host when in docker container
      {radio_device, { {0,0,0,0}, 1680,
                       {0,0,0,0}, 31341} },
-     {use_ebus, false},
-     {gateway_and_mux_enable, true}
+     {use_ebus, false}
     ]}
 ].


### PR DESCRIPTION
hotfix to bypass a packet routing issue in the embedded rust gateway while a pending fix is validated