### PR TITLE
Bump to OTP24 for (debian) builds

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,7 +4,7 @@ set -e
 echo '--- :house_with_garden: Setting up the environment'
 
 . "$HOME/.asdf/asdf.sh"
-asdf local erlang 22.1.8
+asdf local erlang 24.3.4
 asdf local python 3.7.3
 asdf local ruby 2.6.2
 


### PR DESCRIPTION
Problem to solve: We are currently building debs using OTP22. Let's use 24 instead.