### PR TITLE
shim gateway api into ebus interface

### DIFF
--- a/src/miner_ebus.erl
+++ b/src/miner_ebus.erl
@@ -6,11 +6,15 @@
 
 -export([send_signal/2]).
 
--export([start_link/0, start_link/2, init/1, handle_message/3, handle_cast/2]).
+-export([start_link/0, start_link/2, init/1, handle_message/3, handle_cast/2, handle_info/2]).
 
--record(state, {}).
+-record(state, {
+    connection = undefined :: grpc_client:connection() | undefined,
+    grpc_api = false :: boolean()
+}).
 
 -define(SERVER, miner_ebus).
+-define(SERVICE, 'helium.local.api').
 
 -define(MINER_APPLICATION_NAME, "com.helium.Miner").
 -define(MINER_OBJECT_PATH, "/").
@@ -44,17 +48,27 @@ send_signal(Signal, Status) ->
 
 init(_Args) ->
     erlang:register(?SERVER, self()),
-    {ok, #state{}}.
+    {ok, UseGrpc} = application:get_env(miner, gateway_and_mux_enable),
+    {ok, #state{ grpc_api = UseGrpc}}.
 
-
-handle_message(?MINER_OBJECT(?MINER_MEMBER_ADD_GW)=Member, Msg, State=#state{}) ->
+handle_message(Member, Msg, State = #state{ connection = undefined , grpc_api = true }) ->
+    GrpcPort = application:get_env(miner, gateway_api_port, 4468),
+    case grpc_client:connect(tcp, "localhost", GrpcPort) of
+        {ok, Connection = #{http_connection := Pid}} ->
+            erlang:monitor(process, Pid),
+            handle_message(Member, Msg, State#state{ connection = Connection});
+        {error, Error} ->
+            lager:warning("Unable to contact embedded gateway api: ~p", [Error]),
+            {reply_error, ?MINER_ERROR_INTERNAL, Member, State}
+    end;
+handle_message(?MINER_OBJECT(?MINER_MEMBER_ADD_GW) = Member, Msg, State=#state{ grpc_api = false }) ->
     case ebus_message:args(Msg) of
         {ok, [OwnerB58, Fee, StakingFee, PayerB58]} ->
             case (catch blockchain:add_gateway_txn(OwnerB58, PayerB58, Fee, StakingFee)) of
                 {ok, TxnBin} ->
                     {reply, [{array, byte}], [TxnBin], State};
                 {'EXIT', Why} ->
-                    lager:warning("Error requesting assert loc: ~p", [Why]),
+                    lager:warning("Error requesting add gateway: ~p", [Why]),
                     {reply_error, ?MINER_ERROR_BADARGS, Member, State}
             end;
         {ok, Args} ->
@@ -64,34 +78,67 @@ handle_message(?MINER_OBJECT(?MINER_MEMBER_ADD_GW)=Member, Msg, State=#state{}) 
             lager:warning("Invalid add gateway args: ~p", [Error]),
             {reply_error, ?MINER_ERROR_BADARGS, Member, State}
     end;
-handle_message(?MINER_OBJECT(?MINER_MEMBER_ASSERT_LOC)=Member, Msg, State=#state{}) ->
+handle_message(?MINER_OBJECT(?MINER_MEMBER_ADD_GW) = Member, Msg, State=#state{ connection = Connection, grpc_api = true }) ->
     case ebus_message:args(Msg) of
-        {ok, [H3String, OwnerB58, Nonce, StakingFee, Fee, PayerB58]} ->
-            lager:info("Requesting assert for ~p", [H3String]),
-            case (catch blockchain:assert_loc_txn(H3String, OwnerB58, PayerB58, Nonce, StakingFee, Fee)) of
-                {ok, TxnBin} ->
-                    {reply, [{array, byte}], [TxnBin], State};
-                {'EXIT', Why} ->
-                    lager:warning("Error requesting assert loc: ~p", [Why]),
-                    {reply_error, ?MINER_ERROR_BADARGS, Member, State}
+        {ok, [OwnerB58, _Fee, _StakingFee, PayerB58]} ->
+            case
+                call_unary(Connection, add_gateway, #{
+                    owner => libp2p_crypto:b58_to_bin(OwnerB58),
+                    payer => libp2p_crypto:b58_to_bin(PayerB58),
+                    staking_mode => full
+                })
+            of
+                {ok, #{result := #{add_gateway_txn := BinTxn}}} ->
+                    {reply, [{array, byte}], [BinTxn], State};
+                {error, Error} ->
+                    lager:warning("Error requesting add gateway from embedded gateway api: ~p", [Error]),
+                    {reply_error, ?MINER_ERROR_INTERNAL, Member, State#state{ connection = undefined }}
             end;
         {ok, Args} ->
-            lager:warning("Invalid asset_loc args: ~p", [Args]),
+            lager:warning("Invalid add gateway args: ~p", [Args]),
             {reply_error, ?MINER_ERROR_BADARGS, Member, State};
         {error, Error} ->
-            lager:warning("Invalid assert_loc args: ~p", [Error]),
-            {reply_error, ?MINER_ERROR_BADARGS, Member, State}
+            lager:warning("Invalid add gateway args: ~p", [Error]),
+            {reply_error, ?MINER_ERROR_BADARGS, Member, State#state{ connection = undefined }}
     end;
-handle_message(?MINER_OBJECT(?MINER_MEMBER_P2P_STATUS), _, State=#state{}) ->
+handle_message(?MINER_OBJECT(?MINER_MEMBER_ASSERT_LOC) = Member, _Msg, State) ->
+    lager:warning("Assert_loc deprecated; miners now obtain loc data on-chain", []),
+    {reply_error, ?MINER_ERROR_BADARGS, Member, State};
+handle_message(?MINER_OBJECT(?MINER_MEMBER_P2P_STATUS), _Msg, State=#state{ grpc_api = false }) ->
     Status = miner:p2p_status(),
     {reply, [{array, {struct, [string, string]}}], [Status], State};
-handle_message(?MINER_OBJECT(?MINER_MEMBER_BLOCK_AGE), _, State=#state{}) ->
+handle_message(?MINER_OBJECT(?MINER_MEMBER_P2P_STATUS) = _Member, _, State=#state{ connection = Connection, grpc_api = true }) ->
+    case call_unary(Connection, height, #{}) of
+        {ok, #{result := #{height := Height}}} ->
+            Status = [{"connected", "yes"}, {"height", integer_to_list(Height)}],
+            {reply, [{array, {struct, [string, string]}}], [Status], State};
+        {error, Reason} ->
+            lager:warning("Error requesting status from embedded gateway api: ~p", [Reason]),
+            {reply, [{array, {struct, [string, string]}}], [[{"connected", "no"}]], State#state{ connection = undefined }}
+    end;
+handle_message(?MINER_OBJECT(?MINER_MEMBER_BLOCK_AGE), _Msg, State=#state{ grpc_api = false }) ->
     Age = miner:block_age(),
     {reply, [int32], [Age], State};
-handle_message(?MINER_OBJECT(?MINER_MEMBER_HEIGHT), _, State=#state{}) ->
+handle_message(?MINER_OBJECT(?MINER_MEMBER_BLOCK_AGE) = Member, _Msg, State=#state{ connection = Connection, grpc_api = true }) ->
+    case call_unary(Connection, height, #{}) of
+        {ok, #{result := #{block_age := Age}}} ->
+            {reply, [uint64], [Age], State};
+        {error, Reason} ->
+            lager:warning("Error requesting block age from embedded gateway api: ~p", [Reason]),
+            {reply_error, ?MINER_ERROR_INTERNAL, Member, State#state{ connection = undefined }}
+    end;
+handle_message(?MINER_OBJECT(?MINER_MEMBER_HEIGHT), _Msg, State=#state{ grpc_api = false }) ->
     Chain = blockchain_worker:blockchain(),
     {ok, Height} = blockchain:height(Chain),
     {reply, [int32], [Height], State};
+handle_message(?MINER_OBJECT(?MINER_MEMBER_HEIGHT) = Member, _Msg, State=#state{ connection = Connection, grpc_api = true }) ->
+    case call_unary(Connection, height, #{}) of
+        {ok, #{result := #{height := Height}}} ->
+            {reply, [uint64], [Height], State};
+        {error, Reason} ->
+            lager:warning("Error requesting height from embedded gateway api: ~p", [Reason]),
+            {reply_error, ?MINER_ERROR_INTERNAL, Member, State#state{ connection = undefined }}
+    end;
 handle_message(Member, _Msg, State) ->
     lager:warning("Unhandled dbus message ~p", [Member]),
     {reply_error, ?DBUS_ERROR_NOT_SUPPORTED, Member, State}.
@@ -101,3 +148,13 @@ handle_cast({send_signal, Signal, Status}, State) ->
 handle_cast(_Msg, State) ->
     lager:warning("unhandled msg: ~p", [_Msg]),
     {noreply, State}.
+
+handle_info({'DOWN', _Ref, process, Pid, _Info}, State = #state{ connection = #{ http_connection := Pid }}) ->
+    lager:warning("Gateway api grpc connection down; restarting", []),
+    {noreply, State#state{ connection = undefined }};
+handle_info(_Msg, State) ->
+    lager:info("unhandled info message ~p", [_Msg]),
+    {noreply, State}.
+
+call_unary(Connection, Method, Arguments) ->
+    grpc_client:unary(Connection, Arguments, ?SERVICE, Method, local_miner_client_pb, [{timeout, 5000}]).


### PR DESCRIPTION
The pieces of the current implementation of the miner ebus api are being deprecated one by one, including the removal of asserting locations with the change to validator-initiated challenges and now with the disabling of miners following the chain breaking the height, blockage, and related status checks.

This change temporarily grants the ebus interface a stay of execution by having it call into the embedded gateway's local grpc api to retrieve the information and allow makers additional time to transition their firmware off the ebus interface to use the `gateway_config` application.