### PR TITLE
use correct monitor ref

### DIFF
--- a/src/poc/grpc_client_stream_custom.erl
+++ b/src/poc/grpc_client_stream_custom.erl
@@ -248,7 +248,7 @@ handle_info(timeout, #{response_pending := true,
                        client := Client} = Stream) ->
     gen_server:reply(Client, {error, timeout}),
     {noreply, Stream#{response_pending => false}};
-handle_info({'DOWN', Ref, process, _, _Reason}, #{conn_mon := Ref} = C) ->
+handle_info({'DOWN', Ref, process, _, _Reason}, #{conn_monitor_ref := Ref} = C) ->
     %% our connection is down, nothing more stream can do other then terminate
     {stop, connection_down, C};
 handle_info(Msg, #{handler_callback := HandlerCB} = Stream) ->


### PR DESCRIPTION
Fixes incorrect use of the stream connection monitor var name from the state.  Connection monitor var is defined in state here:
https://github.com/helium/miner/blob/master/src/poc/grpc_client_stream_custom.erl#L73

Set here:

https://github.com/helium/miner/blob/master/src/poc/grpc_client_stream_custom.erl#L140

But the DOWN info handler was stupidly looking for `conn_mon` rather than `conn_monitor_ref`

Thanks to community member `nmc` for supplying logs highlighting the issue