### PR TITLE
prevent tagging validator release without updating version in miner.erl

### DIFF
--- a/tag-release.sh
+++ b/tag-release.sh
@@ -13,16 +13,6 @@ dep_hash() {
     git show "${MINER}:rebar.lock" | grep -A2 "${DEP}" | sed -e "s/.*\"\(.*\)\".*/\1/" | tr '\n' ' ' | awk '{print $3}'
 }
 
-strip_zeros() {
-    local VZN=$(echo $1 | sed -e 's/0//g')
-
-    if [[ $VZN == "" ]]; then
-        echo "0"
-    else
-        echo $VZN
-    fi
-}
-
 val_tag() {
     local VAL_VERSION
     local MAJ
@@ -34,7 +24,7 @@ val_tag() {
     MIN=$(echo $VAL_VERSION | awk '{print substr( $0, 4, 3 )}')
     PATCH=$(echo $VAL_VERSION | awk '{print substr( $0, 7, 4 )}')
 
-    echo "validator$(strip_zeros $MAJ).$(strip_zeros $MIN).$(strip_zeros $PATCH)"
+    echo "validator$((10#$MAJ)).$((10#$MIN)).$((10#$PATCH))"
 }
 
 declare -r repos="blockchain libp2p sibyl ecc508 relcast dkg hbbft helium_proto"

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -29,7 +29,7 @@ val_tag() {
     local MIN
     local PATCH
 
-    VAL_VERSION=$(grep -A 1 "%% MMMmmmPPPP" src/miner.erl | grep -o -E '[0-9]+')
+    VAL_VERSION=$(sed -n "/^version() ->$/,/\.$/p" src/miner.erl | grep -o -E '[0-9]{10}')
     MAJ=$(echo $VAL_VERSION | awk '{print substr( $0, 1, 3 )}')
     MIN=$(echo $VAL_VERSION | awk '{print substr( $0, 4, 3 )}')
     PATCH=$(echo $VAL_VERSION | awk '{print substr( $0, 7, 4 )}')


### PR DESCRIPTION
as long as we're tagging our releases with `tag-release.sh` and we don't plan to change the erlang versioning scheme or the tagging strategy for validator tags this should prevent us from publishing a validator release without first updating the version function in `src/miner.erl`