### PR TITLE
Add denylist to cli and jsonrpc

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -79,6 +79,7 @@
           {copy, "scripts/extensions/hbbft", "bin/extensions/hbbft"},
           {copy, "scripts/extensions/info", "bin/extensions/info"},
           {copy, "scripts/extensions/dkg", "bin/extensions/dkg"},
+          {copy, "scripts/extensions/denylist", "bin/extensions/denylist"},
           {copy, "scripts/extensions/authorize", "bin/extensions/authorize"},
           {copy, "scripts/extensions/print_keys", "bin/extensions/print_keys"},
           {copy, "./_build/default/lib/blockchain/scripts/extensions/peer", "bin/extensions/peer"},
@@ -108,6 +109,7 @@
           {trace, "extensions/trace"},
           {txn, "extensions/txn"},
           {dkg, "extensions/dkg"},
+          {denylist, "extensions/denylist"},
           {authorize, "extensions/authorize"},
           {repair, "extensions/repair"},
           {print_keys, "extensions/print_keys"}

--- a/scripts/extensions/denylist
+++ b/scripts/extensions/denylist
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [ -t 0 ] ; then
+    CLIQUE_COLUMNS=$(stty size 2>/dev/null | cut -d ' ' -f 2)
+    export CLIQUE_COLUMNS
+fi
+
+export RELX_RPC_TIMEOUT=${RELX_RPC_TIMEOUT:-900}
+
+j=1
+l=$#
+buf="[[\"denylist\","
+while [ $j -le $l ]; do
+    buf="$buf\"$1\","
+    j=$(( j + 1 ))
+    shift
+done
+
+buf="${buf%?}]]"
+
+relx_nodetool rpc blockchain_console command "$buf"
+exit $?

--- a/src/cli/miner_cli_denylist.erl
+++ b/src/cli/miner_cli_denylist.erl
@@ -1,0 +1,106 @@
+%%%-------------------------------------------------------------------
+%% @doc miner_cli_denylist
+%% @end
+%%%-------------------------------------------------------------------
+-module(miner_cli_denylist).
+
+-behavior(clique_handler).
+
+-export([register_cli/0]).
+
+register_cli() ->
+    register_all_usage(),
+    register_all_cmds().
+
+register_all_usage() ->
+    lists:foreach(fun(Args) ->
+                          apply(clique, register_usage, Args)
+                  end,
+                 [
+                  denylist_usage(),
+                  denylist_status_usage(),
+                  denylist_check_usage()
+                 ]).
+
+register_all_cmds() ->
+    lists:foreach(fun(Cmds) ->
+                          [apply(clique, register_command, Cmd) || Cmd <- Cmds]
+                  end,
+                 [
+                  denylist_cmd(),
+                  denylist_status_cmd(),
+                  denylist_check_cmd()
+                 ]).
+%%
+%% denylist
+%%
+
+denylist_usage() ->
+    [["denylist"],
+     ["miner denylist commands\n\n",
+      "  denylist status           - Display status of denylist.\n"
+      "  denylist check <address>  - Check if address is on denylist.\n"
+     ]
+    ].
+
+denylist_cmd() ->
+    [
+     [["denylist"], [], [], fun(_, _, _) -> usage end]
+    ].
+
+
+%%
+%% denylist status
+%%
+
+denylist_status_cmd() ->
+    [
+     [["denylist", "status"], [], [], fun denylist_status/3]
+    ].
+
+denylist_status_usage() ->
+    [["denylist", "status"],
+     ["denylist status\n\n",
+      "  Display status of denylist.\n\n"
+     ]
+    ].
+
+denylist_status(["denylist", "status"], [], []) ->
+    Text = try miner_poc_denylist:get_version() of 
+        {ok, Version} -> 
+            clique_status:text(io_lib:format("Denylist version ~p loaded", [Version]))
+    catch _:_ ->
+        clique_status:text(io_lib:format("No denylist loaded",[]))
+    end,
+    [Text];
+denylist_status([], [], []) ->
+    usage.
+
+
+%%
+%% denylist check
+%%
+
+denylist_check_cmd() ->
+    [
+     [["denylist", "check", '*'], [], [], fun denylist_check/3]
+    ].
+
+denylist_check_usage() ->
+    [["denylist", "check"],
+     ["denylist check <address>\n\n",
+      "  Check if address is on denylist.\n\n"
+     ]
+    ].
+
+denylist_check(["denylist", "check", Address], [], []) ->
+    Result =
+        try miner_poc_denylist:check(libp2p_crypto:b58_to_bin(Address)) of
+            R -> R
+        catch _:_ ->
+            invalid_address
+        end,
+    Text = clique_status:text(io_lib:format("~p", [Result])),
+    [Text];
+denylist_check([], [], []) ->
+    usage.

--- a/src/cli/miner_cli_info.erl
+++ b/src/cli/miner_cli_info.erl
@@ -6,7 +6,6 @@
 
 -behavior(clique_handler).
 
-
 -export([register_cli/0]).
 
 -export([get_info/0]).

--- a/src/cli/miner_cli_registry.erl
+++ b/src/cli/miner_cli_registry.erl
@@ -9,6 +9,7 @@
                       ,miner_cli_genesis
                       ,miner_cli_info
                       ,miner_cli_dkg
+                      ,miner_cli_denylist
                      ]).
 
 -export([register_cli/0]).

--- a/src/jsonrpc/miner_jsonrpc_denylist.erl
+++ b/src/jsonrpc/miner_jsonrpc_denylist.erl
@@ -1,0 +1,24 @@
+-module(miner_jsonrpc_denylist).
+
+-include("miner_jsonrpc.hrl").
+-behavior(miner_jsonrpc_handler).
+
+-export([handle_rpc/2]).
+
+handle_rpc(<<"denylist_status">>, []) ->
+    try miner_poc_denylist:get_version() of 
+        {ok, Version} -> #{ loaded => true, version => Version }
+    catch _:_ ->
+        #{ loaded => false }
+    end;
+handle_rpc(<<"denylist_status">>, Params) ->
+    ?jsonrpc_error({invalid_params, Params});
+
+handle_rpc(<<"denylist_check">>, #{ <<"address">> := Address}) ->
+    try miner_poc_denylist:check(?B58_TO_BIN(Address)) of
+        Denied -> #{ denied => Denied }
+    catch _:Reason ->
+        ?jsonrpc_error({invalid_params, Reason})
+    end;
+handle_rpc(<<"denylist_check">>, Params) ->
+    ?jsonrpc_error({invalid_params, Params}).

--- a/src/miner_jsonrpc_handler.erl
+++ b/src/miner_jsonrpc_handler.erl
@@ -44,6 +44,8 @@ handle_rpc_(<<"account_", _/binary>> = Method, Params) ->
     miner_jsonrpc_accounts:handle_rpc(Method, Params);
 handle_rpc_(<<"info_", _/binary>> = Method, Params) ->
     miner_jsonrpc_info:handle_rpc(Method, Params);
+handle_rpc_(<<"denylist_", _/binary>> = Method, Params) ->
+    miner_jsonrpc_denylist:handle_rpc(Method, Params);
 handle_rpc_(<<"dkg_", _/binary>> = Method, Params) ->
     miner_jsonrpc_dkg:handle_rpc(Method, Params);
 handle_rpc_(<<"hbbft_", _/binary>> = Method, Params) ->


### PR DESCRIPTION
Based on a request from the community, this change adds basic denylist functionality to the cli and jsonrpc endpoint. Supported methods are:
- `denylist status` which returns whether a denylist is loaded and if so which version
- `denylist check <address>` which returns whether or not the provided hotspot address is on the loaded list; will return true/false only if denylist is loaded and error if the address is not a valid b58 hotspot address