### PR TITLE
update alpine runtime image

### DIFF
--- a/.buildkite/scripts/make_image.sh
+++ b/.buildkite/scripts/make_image.sh
@@ -17,7 +17,7 @@ ERLANG_IMAGE_SOURCE="erlang"
 
 BUILD_IMAGE="${ERLANG_IMAGE_SOURCE}:${ERLANG_IMAGE}"
 
-RUN_IMAGE="alpine:3.15"
+RUN_IMAGE="alpine:3.16"
 
 if [[ "$IMAGE_ARCH" == "arm64" ]]; then
     BUILD_IMAGE="arm64v8/$BUILD_IMAGE"


### PR DESCRIPTION
The official erlang alpine image has updated its base to alpine 3.16 within the last week which is breaking the release now that our runner image is being built a minor version of alpine behind where the release is built. This causes runtime errors with `no symbol found`.