### PR TITLE
add environment variable replacement to disable cache prewarm

### DIFF
--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -22,7 +22,8 @@
    {key, undefined},
    {relay_limit, 100},
    {blocks_to_protect_from_gc, 100000},
-   {base_dir, "/var/data"}
+   {base_dir, "/var/data"},
+   {disable_prewarm, ${DISABLE_PREWARM:-false}}
   ]},
  {libp2p,
   [

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -22,7 +22,8 @@
    {key, undefined},
    {relay_limit, 100},
    {blocks_to_protect_from_gc, 100000},
-   {base_dir, "${BASE_DIR:-data}"}
+   {base_dir, "${BASE_DIR:-data}"},
+   {disable_prewarm, ${DISABLE_PREWARM:-false}}
   ]},
  {libp2p,
   [


### PR DESCRIPTION
Make it a little easier to disable the cache prewarm by allowing DISABLE_PREWARM=true to be set as an environment variable.