### PR TITLE
fix rssi computation from rssic if SNR < 0

### DIFF
--- a/src/miner_lora.erl
+++ b/src/miner_lora.erl
@@ -842,7 +842,11 @@ packet_rssi(Packet, UseRSSIS) ->
                 false ->
                     %% Just use RSSIC.
                     fun (Obj) ->
-                        maps:get(<<"rssic">>, Obj, undefined)
+                        SNR = maps:get(<<"lsnr">>, Obj, 0),
+                        case SNR < 0 of
+                            true -> SNR + maps:get(<<"rssic">>, Obj, undefined);
+                            _ -> maps:get(<<"rssic">>, Obj, undefined)
+                        end
                     end
             end,
             BestRSSISelector =


### PR DESCRIPTION
rssis is supposed to be the useful signal strength
rssic is supposed to be the received signal strength

The blockchain expects the rssi to be the rssis. However when falling back to rssic when rssis is unavailable, the computation is wrong when SNR < 0
Indeed, in that case the useful signal strength is below the noise level, which is rssic. So the rssis = SNR + rssic when SNR < 0
This should help use the appropriate GWMPv2 value from the packet forwarders