### PR TITLE
Add pax-utils to debian Dockerfile packages

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -29,6 +29,7 @@ RUN apt update \
        libtool \
        lz4 \
        libprotobuf-dev \
+       pax-utils \
        wget \
        ${EXTRA_BUILD_APT_PACKAGES} 
 


### PR DESCRIPTION
The scanelf command is failing due to this a missing package. This change adds pax-utils to the apt packages installed in the builder image. The scanelf command is used to strip debugging symbols from the ERTS binaries thus reducing them and the final image in size by 40+MB .