### PR TITLE
add ability to not gossip with miners

### DIFF
--- a/config/docker-val.config.src
+++ b/config/docker-val.config.src
@@ -27,7 +27,7 @@
   ]},
  {libp2p,
   [
-   {random_peer_pred, fun miner_util:true_predicate/1},
+   {random_peer_pred, fun miner_util:random_non_miner_predicate/1},
    {nat_map, #{ {"${NAT_INTERNAL_IP}", "${NAT_INTERNAL_PORT}"} => {"${NAT_EXTERNAL_IP}", "${NAT_EXTERNAL_PORT}"}}},
    {max_tcp_connections, 2048}
   ]},

--- a/config/val.config.src
+++ b/config/val.config.src
@@ -27,7 +27,7 @@
   ]},
  {libp2p,
   [
-   {random_peer_pred, fun miner_util:true_predicate/1},
+   {random_peer_pred, fun miner_util:random_non_miner_predicate/1},
    {nat_map, #{ {"${NAT_INTERNAL_IP}", "${NAT_INTERNAL_PORT}"} => {"${NAT_EXTERNAL_IP}", "${NAT_EXTERNAL_PORT}"}}},
    {max_tcp_connections, 2048}
   ]

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -15,6 +15,7 @@
          metadata_fun/0,
          random_val_predicate/1,
          random_miner_predicate/1,
+         random_non_miner_predicate/1,
          true_predicate/1,
          has_valid_local_capability/2,
          hbbft_perf/0,
@@ -143,6 +144,10 @@ random_val_predicate(Peer) ->
 random_miner_predicate(Peer) ->
     not libp2p_peer:is_stale(Peer, timer:minutes(360)) andalso
         maps:get(<<"release_info">>, libp2p_peer:signed_metadata(Peer), undefined) /= undefined.
+
+random_non_miner_predicate(Peer) ->
+    not libp2p_peer:is_stale(Peer, timer:minutes(360)) andalso
+        maps:get(<<"release_info">>, libp2p_peer:signed_metadata(Peer), undefined) == undefined.
 
 true_predicate(_Peer) ->
     true.

--- a/src/miner_util.erl
+++ b/src/miner_util.erl
@@ -147,7 +147,7 @@ random_miner_predicate(Peer) ->
 
 random_non_miner_predicate(Peer) ->
     not libp2p_peer:is_stale(Peer, timer:minutes(360)) andalso
-        maps:get(<<"release_info">>, libp2p_peer:signed_metadata(Peer), undefined) == undefined.
+        maps:get(<<"node_type">>, libp2p_peer:signed_metadata(Peer), undefined) /= <<"gateway">>.
 
 true_predicate(_Peer) ->
     true.


### PR DESCRIPTION
since the miner stopped following the chain, not connecting to them blackholes a gossip link, making it hard for certain nodes to connect to active chain followers and stay synced.  this PR makes prefer non-miners as gossip peers, hopefully improving sync until we can remove the miners from the gossip network, at which point we can tune down the number of active connections.